### PR TITLE
feat: add hfdownload CLI tool

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Pack
         run: |
           dotnet pack src/ElBruno.HuggingFace.Downloader/ElBruno.HuggingFace.Downloader.csproj -c Release --no-build -p:Version=${{ steps.version.outputs.version }} -o artifacts
+          dotnet pack src/ElBruno.HuggingFace.Downloader.Cli/ElBruno.HuggingFace.Downloader.Cli.csproj -c Release --no-build -p:Version=${{ steps.version.outputs.version }} -o artifacts
 
       - name: NuGet login (OIDC → temp API key)
         uses: NuGet/login@v1

--- a/.squad/agents/tank/charter.md
+++ b/.squad/agents/tank/charter.md
@@ -1,0 +1,24 @@
+# Tank — CLI Developer
+
+## Role
+CLI Developer — command design, console UX, dotnet tool packaging, System.CommandLine integration.
+
+## Responsibilities
+- Design and implement CLI commands using System.CommandLine
+- Console output formatting (progress bars, tables, colors)
+- Dotnet tool packaging and NuGet publishing configuration
+- Argument validation and help text
+- Cross-platform CLI behavior (Windows, Linux, macOS)
+
+## Boundaries
+- Does NOT modify the core library (`ElBruno.HuggingFace.Downloader`)
+- Consumes the library as a project reference
+- CLI project lives in `src/ElBruno.HuggingFace.Downloader.Cli/`
+- Follows existing code conventions (C# 12+, sealed classes, XML docs)
+
+## Reviewers
+- Neo reviews architecture decisions
+- Agent Smith reviews test coverage
+
+## Model
+Preferred: auto

--- a/.squad/agents/tank/history.md
+++ b/.squad/agents/tank/history.md
@@ -1,0 +1,18 @@
+# Tank — History
+
+## Project Context
+**Project:** ElBruno.HuggingFace.Downloader
+**Stack:** C# 12+, .NET 8/10, NuGet package
+**Author:** Bruno Capuano
+**Description:** A .NET library for downloading files from Hugging Face Hub repositories with progress reporting, caching, atomic writes, and HF_TOKEN authentication support.
+
+## Learnings
+- System.CommandLine 2.0.0-beta5 uses `command.Add(sub)`, `command.SetAction(action)`, and `new CommandLineConfiguration(root).InvokeAsync(args)` — API broke from beta4's `AddCommand`/`SetHandler`/`InvokeAsync`.
+- CLI project lives at `src/ElBruno.HuggingFace.Downloader.Cli/` with namespace `ElBruno.HuggingFace.Cli`.
+- CLI tool command name: `hfdownload`. PackageId: `ElBruno.HuggingFace.Downloader.Cli`.
+- Library targets `net8.0;net10.0` (not net9.0). CLI matches those TFMs.
+- Spectre.Console 0.50.0 is included for future console UX (progress bars, tables, colors).
+- The .slnx format uses `<Folder Name="/src/">` grouping for solution folders.
+- Pack output goes to `src/ElBruno.HuggingFace.Downloader.Cli/nupkg/`.
+- Multi-TFM `dotnet run` prompts for framework selection interactively; use `--framework net8.0` to avoid.
+- Subcommands: download, check, list, info, delete, delete-file, purge, config — all stubbed with "Not yet implemented" messages.

--- a/.squad/agents/tank/history.md
+++ b/.squad/agents/tank/history.md
@@ -16,3 +16,14 @@
 - Pack output goes to `src/ElBruno.HuggingFace.Downloader.Cli/nupkg/`.
 - Multi-TFM `dotnet run` prompts for framework selection interactively; use `--framework net8.0` to avoid.
 - Subcommands: download, check, list, info, delete, delete-file, purge, config — all stubbed with "Not yet implemented" messages.
+- Phase 3 cache commands (list, info, delete, delete-file, purge) implemented with CacheManager service and Spectre.Console table output.
+- Phase 2 download & check commands fully implemented. download uses Spectre.Console Progress() for live progress bars; check uses MarkupLine with ✅/❌ emoji output.
+- System.CommandLine beta5 constructors: `Argument<T>(string name)` and `Option<T>(string name, params string[] aliases)`. Description and DefaultValueFactory set via object initializer properties, NOT constructor params.
+- Spectre.Console `MarkupLine` interprets `[...]` as markup tags. Literal brackets must be escaped as `[[` and `]]`. User strings must go through `Markup.Escape()`.
+- SetAction overload `Func<ParseResult, CancellationToken, Task<int>>` enables async handlers with exit code returns. Synchronous variant `Func<ParseResult, int>` works for non-async commands like check.
+- Cache convention: each immediate subdirectory of the cache root = one model (dir name = sanitized repo ID via DefaultPathHelper.SanitizeModelName).
+- CacheManager.ResolveModelPath tries sanitized name first, then falls back to direct name match. Includes path traversal protection on file deletes.
+- System.CommandLine beta5 SetAction with `(ParseResult, CancellationToken) => Task<int>` supports exit code propagation; returning `Task.FromResult(1)` sets non-zero exit.
+- `ElBruno.HuggingFace` types (DefaultPathHelper, ByteFormatHelper) are accessible from child namespaces without explicit `using` due to C# namespace resolution, but explicit usings are harmless.
+- For Spectre.Console interactive prompts (AnsiConsole.Confirm), provide `--force`/`-f` flag to skip in non-interactive/CI contexts.
+- All command classes are `static` with a `Create()` factory method that returns a fully-wired `Command` instance.

--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -69,3 +69,13 @@ During Phase 1 security & validation testing, Agent Smith discovered two validat
 
 **Recommendation:** Add `ArgumentException.ThrowIfNullOrWhiteSpace()` guards (1 line each) at method entry. Tests already document current behavior. Not blocking Phase 4 implementation but should be hardened before next release.
 
+### 2026-04-08: CLI Project Now References Library
+
+Tank created the ElBruno.HuggingFace.Downloader.Cli project (Phase 1 scaffolding). The CLI tool now references the core library via project reference (`ProjectReference` in .csproj). This means:
+
+- **Library remains stable** — no changes needed to library code
+- **CLI builds against published library APIs** — good integration point for Trinity if API refinements needed
+- **Shared dependency model** — CLI inherits all library dependencies (Extensions, Logging abstractions, etc.)
+
+No action needed from Trinity. Library code remains as-is for CLI consumption.
+

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -1,9 +1,9 @@
 ---
-updated_at: 2026-02-28T19:01:51.802Z
-focus_area: Initial setup
+updated_at: 2026-04-08T16:34:00Z
+focus_area: CLI tool planning
 active_issues: []
 ---
 
 # What We're Focused On
 
-Getting started. Updated by coordinator at session start.
+Planning a CLI tool (`hfdownload`) — a dotnet global tool wrapping the existing library. Tank (CLI Developer) joined the team. 6 phases planned, not yet implementing.

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -14,7 +14,9 @@ Route work to squad members based on task domain and agent expertise.
 | **Publishing / Releases** | Morpheus | Neo | Neo |
 | **Performance & Caching** | Trinity | Agent Smith | Neo |
 | **Error Handling & Resilience** | Trinity | Agent Smith | Neo |
-| **NuGet Package** | Morpheus | Trinity | Neo |
+| **CLI Tool / Commands** | Tank | Trinity | Neo |
+| **Console UX / Output** | Tank | Morpheus | Neo |
+| **NuGet Package** | Morpheus | Tank | Neo |
 
 ## By Task Type
 

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -17,6 +17,7 @@ A .NET library for downloading files from Hugging Face Hub repositories with pro
 | Trinity | Backend/Library Dev | Core downloader implementation, API design, service integration | 🔧 |
 | Agent Smith | Test Architect | Test strategy, edge cases, integration tests, CI resilience | 🧪 |
 | Morpheus | Documentation/DevRel | API guides, getting started, examples, publishing workflows | 📝 |
+| Tank | CLI Developer | Command design, console UX, dotnet tool packaging | ⚙️ |
 | Scribe | Session Logger | Decisions, memories, session logs | 📋 |
 | Ralph | Work Monitor | Issue triage, backlog, keep-alive | 🔄 |
 

--- a/ElBruno.HuggingFace.Downloader.slnx
+++ b/ElBruno.HuggingFace.Downloader.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="src\ElBruno.HuggingFace.Downloader\ElBruno.HuggingFace.Downloader.csproj" />
+    <Project Path="src\ElBruno.HuggingFace.Downloader.Cli\ElBruno.HuggingFace.Downloader.Cli.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests\ElBruno.HuggingFace.Downloader.Tests\ElBruno.HuggingFace.Downloader.Tests.csproj" />

--- a/ElBruno.HuggingFace.Downloader.slnx
+++ b/ElBruno.HuggingFace.Downloader.slnx
@@ -5,5 +5,6 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests\ElBruno.HuggingFace.Downloader.Tests\ElBruno.HuggingFace.Downloader.Tests.csproj" />
+    <Project Path="tests\ElBruno.HuggingFace.Downloader.Cli.Tests\ElBruno.HuggingFace.Downloader.Cli.Tests.csproj" />
   </Folder>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/elbruno/ElBruno.HuggingFace.Downloader?style=social)](https://github.com/elbruno/ElBruno.HuggingFace.Downloader)
 [![Twitter Follow](https://img.shields.io/twitter/follow/elbruno?style=social)](https://twitter.com/elbruno)
 
-A .NET library to download files (ONNX models, tokenizers, voice presets, etc.) from [Hugging Face Hub](https://huggingface.co) repositories with progress reporting, caching, and authentication support.
+A .NET library and CLI tool to download files (ONNX models, tokenizers, voice presets, etc.) from [Hugging Face Hub](https://huggingface.co) repositories with progress reporting, caching, and authentication support.
 
 ## Features
 
@@ -23,11 +23,40 @@ A .NET library to download files (ONNX models, tokenizers, voice presets, etc.) 
 
 ## Installation
 
+### Library (NuGet)
+
 ```bash
 dotnet add package ElBruno.HuggingFace.Downloader
 ```
 
-## Quick Start
+### CLI Tool
+
+```bash
+dotnet tool install -g ElBruno.HuggingFace.Downloader.Cli
+```
+
+Once installed, use the `hfdownload` command:
+
+```bash
+# Download model files
+hfdownload download sentence-transformers/all-MiniLM-L6-v2 onnx/model.onnx tokenizer.json
+
+# Check if files exist locally
+hfdownload check sentence-transformers/all-MiniLM-L6-v2 onnx/model.onnx tokenizer.json
+
+# List cached models
+hfdownload list
+
+# Delete a cached model
+hfdownload delete sentence-transformers/all-MiniLM-L6-v2
+
+# See all commands
+hfdownload --help
+```
+
+See the full [CLI Reference](docs/CLI_REFERENCE.md) for all commands and options.
+
+## Quick Start (Library)
 
 ### 1) Download model files
 
@@ -120,6 +149,7 @@ public class MyModelService(HuggingFaceDownloader downloader)
 | Topic | Description |
 |-------|-------------|
 | [Getting Started](docs/GETTING_STARTED.md) | Installation, all usage examples, and setup |
+| [CLI Reference](docs/CLI_REFERENCE.md) | Complete CLI command reference |
 | [API Reference](docs/API_REFERENCE.md) | Complete class and method documentation |
 | [Architecture](docs/ARCHITECTURE.md) | Design decisions, data flow, and project structure |
 | [Publishing](docs/publishing.md) | NuGet publishing with GitHub Actions |

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1,0 +1,311 @@
+# CLI Reference — `hfdownload`
+
+The `hfdownload` CLI tool provides a command-line interface for downloading, managing, and inspecting cached models from [Hugging Face Hub](https://huggingface.co).
+
+## Installation
+
+```bash
+dotnet tool install -g ElBruno.HuggingFace.Downloader.Cli
+```
+
+After installation, the `hfdownload` command is available globally.
+
+## Commands
+
+### `download` — Download files from a Hugging Face repository
+
+```bash
+hfdownload download <repo-id> <files...> [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `<repo-id>` | Hugging Face repository ID (e.g., `microsoft/Phi-4-mini-instruct-onnx`) |
+| `<files>` | One or more files to download, relative to the repo root |
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-o, --output <dir>` | Local directory for downloaded files | Platform cache dir |
+| `-r, --revision <ref>` | Git revision — branch, tag, or commit SHA | `main` |
+| `-t, --token <token>` | Hugging Face auth token (overrides `HF_TOKEN` env var) | — |
+| `--optional` | Treat listed files as optional (skip failures) | `false` |
+| `--no-progress` | Suppress progress bar output | `false` |
+| `-q, --quiet` | Minimal output (only errors) | `false` |
+
+**Examples:**
+
+```bash
+# Download specific files from a public repo
+hfdownload download sentence-transformers/all-MiniLM-L6-v2 onnx/model.onnx tokenizer.json
+
+# Download to a specific directory
+hfdownload download microsoft/Phi-4-mini-instruct-onnx model.onnx -o ./my-models
+
+# Download from a private repo with token
+hfdownload download my-org/private-model weights.bin -t hf_your_token
+
+# Download optional files (skip on failure)
+hfdownload download my-org/model config.json --optional
+
+# Quiet mode for scripts
+hfdownload download my-org/model weights.bin -q
+```
+
+---
+
+### `check` — Check if files exist in the local cache
+
+```bash
+hfdownload check <repo-id> <files...> [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `<repo-id>` | Hugging Face repository ID |
+| `<files>` | Files to check |
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-o, --output <dir>` | Local directory to check | Platform cache dir |
+
+**Output:** Shows ✅ for present files and ❌ for missing files, plus a summary.
+
+**Exit codes:** `0` if all files present, `1` if any missing.
+
+**Example:**
+
+```bash
+hfdownload check sentence-transformers/all-MiniLM-L6-v2 onnx/model.onnx tokenizer.json
+# ✅ onnx/model.onnx
+# ❌ tokenizer.json
+# 1 of 2 files present
+```
+
+---
+
+### `list` — List downloaded models
+
+```bash
+hfdownload list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--cache-dir <dir>` | Cache directory to scan | Platform default |
+| `--format <table\|json>` | Output format | `table` |
+
+**Example:**
+
+```bash
+hfdownload list
+# ┌──────────────────────────────┬───────┬──────────┬──────────────────┐
+# │ Model                        │ Files │     Size │ Last Modified    │
+# ├──────────────────────────────┼───────┼──────────┼──────────────────┤
+# │ sentence-transformers_all-…  │     3 │  85.2 MB │ 2025-01-15 10:30 │
+# │ microsoft_phi-4-mini-…       │     2 │   2.1 GB │ 2025-01-14 09:15 │
+# └──────────────────────────────┴───────┴──────────┴──────────────────┘
+
+hfdownload list --format json
+```
+
+---
+
+### `info` — Show details of a cached model
+
+```bash
+hfdownload info <repo-id> [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `<repo-id>` | Repository ID of the cached model |
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--cache-dir <dir>` | Cache directory | Platform default |
+| `--format <table\|json>` | Output format | `table` |
+
+**Example:**
+
+```bash
+hfdownload info sentence-transformers/all-MiniLM-L6-v2
+```
+
+---
+
+### `delete` — Delete a cached model
+
+```bash
+hfdownload delete <repo-id> [options]
+```
+
+Deletes all files for the specified model. Prompts for confirmation unless `--force` is used.
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--cache-dir <dir>` | Cache directory | Platform default |
+| `-f, --force` | Skip confirmation prompt | `false` |
+
+**Example:**
+
+```bash
+# Interactive (with confirmation)
+hfdownload delete sentence-transformers/all-MiniLM-L6-v2
+
+# Non-interactive (for scripts)
+hfdownload delete sentence-transformers/all-MiniLM-L6-v2 --force
+```
+
+---
+
+### `delete-file` — Delete a single file from a cached model
+
+```bash
+hfdownload delete-file <repo-id> <file> [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `<repo-id>` | Repository ID of the cached model |
+| `<file>` | File to delete, relative to the model directory |
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--cache-dir <dir>` | Cache directory | Platform default |
+| `-f, --force` | Skip confirmation prompt | `false` |
+
+---
+
+### `purge` — Delete all cached models
+
+```bash
+hfdownload purge [options]
+```
+
+Deletes the **entire** cache directory contents. Prompts for confirmation unless `--force` is used.
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--cache-dir <dir>` | Cache directory | Platform default |
+| `-f, --force` | Skip confirmation prompt | `false` |
+
+**Example:**
+
+```bash
+hfdownload purge --force
+```
+
+---
+
+### `config` — Show or modify configuration
+
+#### `config show`
+
+```bash
+hfdownload config show
+```
+
+Displays all current configuration values and the config file location.
+
+#### `config set`
+
+```bash
+hfdownload config set <key> <value>
+```
+
+**Available keys:**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `cache-dir` | Default cache directory | Platform default |
+| `default-token` | Default Hugging Face auth token | (not set) |
+| `default-revision` | Default Git revision | `main` |
+| `no-progress` | Suppress progress bars by default | `false` |
+
+**Example:**
+
+```bash
+hfdownload config set cache-dir /data/hf-models
+hfdownload config set default-revision v2.0
+hfdownload config set no-progress true
+```
+
+#### `config reset`
+
+```bash
+hfdownload config reset [--force]
+```
+
+Resets all configuration to defaults by deleting the config file.
+
+---
+
+## Authentication
+
+The tool supports Hugging Face authentication for private and gated repositories:
+
+1. **Environment variable** (recommended): Set `HF_TOKEN`
+   ```bash
+   export HF_TOKEN=hf_your_token_here
+   ```
+
+2. **Command-line option**: Use `--token` on the `download` command
+   ```bash
+   hfdownload download my-org/private-model model.bin --token hf_your_token
+   ```
+
+3. **Persistent config**: Store in configuration
+   ```bash
+   hfdownload config set default-token hf_your_token_here
+   ```
+
+## Cache Directory
+
+By default, downloaded models are stored in a platform-specific cache directory:
+
+| Platform | Default Path |
+|----------|-------------|
+| Windows | `%LOCALAPPDATA%\hfdownload\models` |
+| Linux | `~/.local/share/hfdownload/models` |
+| macOS | `~/Library/Application Support/hfdownload/models` |
+
+Override with `--cache-dir` on any command, or set a default via `hfdownload config set cache-dir <path>`.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Error (missing files, auth failure, not found, etc.) |
+
+## Configuration File
+
+The config file is stored at:
+
+| Platform | Path |
+|----------|------|
+| Windows | `%APPDATA%\hfdownload\config.json` |
+| Linux | `~/.config/hfdownload/config.json` |
+| macOS | `~/.config/hfdownload/config.json` |

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Commands/CheckCommand.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Commands/CheckCommand.cs
@@ -1,0 +1,83 @@
+using System.CommandLine;
+using ElBruno.HuggingFace;
+using Spectre.Console;
+
+namespace ElBruno.HuggingFace.Cli.Commands;
+
+/// <summary>
+/// Defines the <c>check</c> command for verifying that files exist in the local cache.
+/// </summary>
+internal static class CheckCommand
+{
+    /// <summary>
+    /// Creates a fully configured <c>check</c> <see cref="Command"/>.
+    /// </summary>
+    public static Command Create()
+    {
+        var repoIdArg = new Argument<string>("repo-id")
+        {
+            Description = "Hugging Face repository ID (e.g., microsoft/Phi-4-mini-instruct-onnx)"
+        };
+
+        var filesArg = new Argument<string[]>("files")
+        {
+            Description = "Files to check, relative to the repo root",
+            Arity = ArgumentArity.OneOrMore
+        };
+
+        var outputOption = new Option<string?>("--output", "-o")
+        {
+            Description = "Local directory to check (defaults to the hfdownload cache)"
+        };
+
+        var revisionOption = new Option<string>("--revision", "-r")
+        {
+            Description = "Git revision (kept for consistency with download command)",
+            DefaultValueFactory = _ => "main"
+        };
+
+        var command = new Command("check", "Check if files exist in the local cache");
+        command.Add(repoIdArg);
+        command.Add(filesArg);
+        command.Add(outputOption);
+        command.Add(revisionOption);
+
+        command.SetAction((ParseResult parseResult) =>
+        {
+            var repoId = parseResult.GetRequiredValue(repoIdArg);
+            var files = parseResult.GetValue(filesArg) ?? [];
+            var output = parseResult.GetValue(outputOption);
+
+            var localDir = output
+                ?? Path.Combine(
+                    DefaultPathHelper.GetDefaultCacheDirectory("hfdownload"),
+                    DefaultPathHelper.SanitizeModelName(repoId));
+
+            int present = 0;
+            int missing = 0;
+
+            foreach (var file in files)
+            {
+                var localPath = Path.Combine(localDir, file.Replace('/', Path.DirectorySeparatorChar));
+
+                if (File.Exists(localPath))
+                {
+                    AnsiConsole.MarkupLine($"  [green]✅[/] {Markup.Escape(file)}");
+                    present++;
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"  [red]❌[/] {Markup.Escape(file)}");
+                    missing++;
+                }
+            }
+
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine($"[bold]{present}[/] of [bold]{files.Length}[/] files present in [dim]{Markup.Escape(localDir)}[/]");
+
+            return missing == 0 ? 0 : 1;
+        });
+
+        return command;
+    }
+}

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Commands/ConfigCommand.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Commands/ConfigCommand.cs
@@ -1,0 +1,136 @@
+using System.CommandLine;
+using ElBruno.HuggingFace;
+using ElBruno.HuggingFace.Cli.Models;
+using ElBruno.HuggingFace.Cli.Services;
+using Spectre.Console;
+
+namespace ElBruno.HuggingFace.Cli.Commands;
+
+/// <summary>
+/// The <c>config</c> command — show, set, or reset persistent CLI configuration.
+/// </summary>
+public static class ConfigCommand
+{
+    /// <summary>
+    /// Creates the <c>config</c> <see cref="Command"/> with subcommands: show, set, reset.
+    /// </summary>
+    public static Command Create()
+    {
+        var command = new Command("config", "Show or modify configuration");
+        command.Add(CreateShowCommand());
+        command.Add(CreateSetCommand());
+        command.Add(CreateResetCommand());
+        return command;
+    }
+
+    private static Command CreateShowCommand()
+    {
+        var command = new Command("show", "Display current configuration");
+
+        command.SetAction((_, _) =>
+        {
+            var manager = new ConfigManager();
+            var config = manager.Load();
+            var configPath = ConfigManager.GetConfigPath();
+
+            var table = new Table();
+            table.AddColumn("Key");
+            table.AddColumn("Value");
+
+            foreach (var (key, description) in CliConfig.KnownKeys)
+            {
+                var value = ConfigManager.GetValue(config, key) ?? "(unknown)";
+                table.AddRow(
+                    $"[bold]{Markup.Escape(key)}[/] [dim]({Markup.Escape(description)})[/]",
+                    Markup.Escape(value));
+            }
+
+            AnsiConsole.Write(table);
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine($"[dim]Config file:[/] {Markup.Escape(configPath)}");
+            AnsiConsole.MarkupLine($"[dim]Cache dir:[/]   {Markup.Escape(config.CacheDirectory ?? DefaultPathHelper.GetDefaultCacheDirectory("hfdownload"))}");
+
+            return Task.FromResult(0);
+        });
+
+        return command;
+    }
+
+    private static Command CreateSetCommand()
+    {
+        var keyArg = new Argument<string>("key")
+        {
+            Description = "Configuration key to set"
+        };
+        keyArg.AcceptOnlyFromAmong([.. CliConfig.KnownKeys.Keys]);
+
+        var valueArg = new Argument<string>("value")
+        {
+            Description = "New value for the configuration key"
+        };
+
+        var command = new Command("set", "Set a configuration value");
+        command.Add(keyArg);
+        command.Add(valueArg);
+
+        command.SetAction((parseResult, _) =>
+        {
+            var key = parseResult.GetValue(keyArg)!;
+            var value = parseResult.GetValue(valueArg)!;
+
+            var manager = new ConfigManager();
+            var config = manager.Load();
+
+            if (!manager.SetValue(config, key, value))
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] Invalid value [bold]{Markup.Escape(value)}[/] for key [bold]{Markup.Escape(key)}[/]");
+                return Task.FromResult(1);
+            }
+
+            manager.Save(config);
+            AnsiConsole.MarkupLine($"[green]✓[/] Set [bold]{Markup.Escape(key)}[/] = {Markup.Escape(value)}");
+            return Task.FromResult(0);
+        });
+
+        return command;
+    }
+
+    private static Command CreateResetCommand()
+    {
+        var forceOption = new Option<bool>("--force", "-f")
+        {
+            Description = "Skip confirmation prompt"
+        };
+
+        var command = new Command("reset", "Reset configuration to defaults");
+        command.Add(forceOption);
+
+        command.SetAction((parseResult, _) =>
+        {
+            var force = parseResult.GetValue(forceOption);
+
+            if (!force)
+            {
+                if (!AnsiConsole.Confirm("Reset all configuration to defaults?", defaultValue: false))
+                {
+                    AnsiConsole.MarkupLine("[yellow]Cancelled.[/]");
+                    return Task.FromResult(0);
+                }
+            }
+
+            var manager = new ConfigManager();
+            if (manager.Reset())
+            {
+                AnsiConsole.MarkupLine("[green]✓[/] Configuration reset to defaults.");
+            }
+            else
+            {
+                AnsiConsole.MarkupLine("[dim]No config file found — already using defaults.[/]");
+            }
+
+            return Task.FromResult(0);
+        });
+
+        return command;
+    }
+}

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Commands/DeleteCommand.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Commands/DeleteCommand.cs
@@ -1,0 +1,74 @@
+using System.CommandLine;
+using ElBruno.HuggingFace;
+using ElBruno.HuggingFace.Cli.Services;
+using Spectre.Console;
+
+namespace ElBruno.HuggingFace.Cli.Commands;
+
+/// <summary>
+/// The <c>delete</c> command — deletes a cached model and all its files.
+/// </summary>
+public static class DeleteCommand
+{
+    /// <summary>
+    /// Creates the <c>delete</c> <see cref="Command"/> with arguments, options, and handler.
+    /// </summary>
+    public static Command Create()
+    {
+        var repoIdArgument = new Argument<string>("repo-id")
+        {
+            Description = "Repository ID of the cached model to delete"
+        };
+
+        var cacheDirOption = new Option<string>("--cache-dir")
+        {
+            Description = "Cache directory containing downloaded models",
+            DefaultValueFactory = _ => DefaultPathHelper.GetDefaultCacheDirectory("hfdownload")
+        };
+
+        var forceOption = new Option<bool>("--force", "-f")
+        {
+            Description = "Skip confirmation prompt"
+        };
+
+        var command = new Command("delete", "Delete a cached model and all its files");
+        command.Add(repoIdArgument);
+        command.Add(cacheDirOption);
+        command.Add(forceOption);
+
+        command.SetAction((parseResult, _) =>
+        {
+            var repoId = parseResult.GetValue(repoIdArgument)!;
+            var cacheDir = parseResult.GetValue(cacheDirOption)!;
+            var force = parseResult.GetValue(forceOption);
+
+            var manager = new CacheManager();
+            var model = manager.GetModelDetails(cacheDir, repoId);
+
+            if (model is null)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] Model [bold]{Markup.Escape(repoId)}[/] not found in {Markup.Escape(cacheDir)}");
+                return Task.FromResult(1);
+            }
+
+            AnsiConsole.MarkupLine($"Model:  [bold]{Markup.Escape(model.Name)}[/]");
+            AnsiConsole.MarkupLine($"Files:  {model.FileCount}");
+            AnsiConsole.MarkupLine($"Size:   {ByteFormatHelper.FormatBytes(model.TotalSize)}");
+
+            if (!force)
+            {
+                if (!AnsiConsole.Confirm("Are you sure you want to delete this model?", defaultValue: false))
+                {
+                    AnsiConsole.MarkupLine("[yellow]Cancelled.[/]");
+                    return Task.FromResult(0);
+                }
+            }
+
+            manager.DeleteModel(cacheDir, repoId);
+            AnsiConsole.MarkupLine($"[green]Deleted model[/] [bold]{Markup.Escape(model.Name)}[/] ({ByteFormatHelper.FormatBytes(model.TotalSize)})");
+            return Task.FromResult(0);
+        });
+
+        return command;
+    }
+}

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Commands/DeleteFileCommand.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Commands/DeleteFileCommand.cs
@@ -1,0 +1,102 @@
+using System.CommandLine;
+using ElBruno.HuggingFace;
+using ElBruno.HuggingFace.Cli.Services;
+using Spectre.Console;
+
+namespace ElBruno.HuggingFace.Cli.Commands;
+
+/// <summary>
+/// The <c>delete-file</c> command — deletes a single file from a cached model.
+/// </summary>
+public static class DeleteFileCommand
+{
+    /// <summary>
+    /// Creates the <c>delete-file</c> <see cref="Command"/> with arguments, options, and handler.
+    /// </summary>
+    public static Command Create()
+    {
+        var repoIdArgument = new Argument<string>("repo-id")
+        {
+            Description = "Repository ID of the cached model"
+        };
+
+        var fileArgument = new Argument<string>("file")
+        {
+            Description = "Relative path of the file to delete within the model directory"
+        };
+
+        var cacheDirOption = new Option<string>("--cache-dir")
+        {
+            Description = "Cache directory containing downloaded models",
+            DefaultValueFactory = _ => DefaultPathHelper.GetDefaultCacheDirectory("hfdownload")
+        };
+
+        var forceOption = new Option<bool>("--force", "-f")
+        {
+            Description = "Skip confirmation prompt"
+        };
+
+        var command = new Command("delete-file", "Delete a single file from a cached model");
+        command.Add(repoIdArgument);
+        command.Add(fileArgument);
+        command.Add(cacheDirOption);
+        command.Add(forceOption);
+
+        command.SetAction((parseResult, _) =>
+        {
+            var repoId = parseResult.GetValue(repoIdArgument)!;
+            var filePath = parseResult.GetValue(fileArgument)!;
+            var cacheDir = parseResult.GetValue(cacheDirOption)!;
+            var force = parseResult.GetValue(forceOption);
+
+            var manager = new CacheManager();
+            var model = manager.GetModelDetails(cacheDir, repoId);
+
+            if (model is null)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] Model [bold]{Markup.Escape(repoId)}[/] not found in {Markup.Escape(cacheDir)}");
+                return Task.FromResult(1);
+            }
+
+            // Check if file exists within the model
+            var matchingFile = model.Files.FirstOrDefault(
+                f => string.Equals(f.RelativePath, filePath, StringComparison.OrdinalIgnoreCase));
+
+            if (matchingFile is null)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] File [bold]{Markup.Escape(filePath)}[/] not found in model {Markup.Escape(model.Name)}");
+                return Task.FromResult(1);
+            }
+
+            AnsiConsole.MarkupLine($"Model:  [bold]{Markup.Escape(model.Name)}[/]");
+            AnsiConsole.MarkupLine($"File:   {Markup.Escape(matchingFile.RelativePath)}");
+            AnsiConsole.MarkupLine($"Size:   {ByteFormatHelper.FormatBytes(matchingFile.Size)}");
+
+            if (!force)
+            {
+                if (!AnsiConsole.Confirm("Are you sure you want to delete this file?", defaultValue: false))
+                {
+                    AnsiConsole.MarkupLine("[yellow]Cancelled.[/]");
+                    return Task.FromResult(0);
+                }
+            }
+
+            var deleted = manager.DeleteFile(cacheDir, repoId, filePath);
+            if (deleted)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[green]Deleted file[/] [bold]{Markup.Escape(matchingFile.RelativePath)}[/] " +
+                    $"from {Markup.Escape(model.Name)} ({ByteFormatHelper.FormatBytes(matchingFile.Size)})");
+            }
+            else
+            {
+                AnsiConsole.MarkupLine("[red]Error:[/] Failed to delete the file.");
+                return Task.FromResult(1);
+            }
+
+            return Task.FromResult(0);
+        });
+
+        return command;
+    }
+}

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Commands/DownloadCommand.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Commands/DownloadCommand.cs
@@ -1,0 +1,269 @@
+using System.CommandLine;
+using System.Diagnostics;
+using ElBruno.HuggingFace;
+using Spectre.Console;
+
+namespace ElBruno.HuggingFace.Cli.Commands;
+
+/// <summary>
+/// Defines the <c>download</c> command for fetching files from a Hugging Face repository.
+/// </summary>
+internal static class DownloadCommand
+{
+    /// <summary>
+    /// Creates a fully configured <c>download</c> <see cref="Command"/>.
+    /// </summary>
+    public static Command Create()
+    {
+        var repoIdArg = new Argument<string>("repo-id")
+        {
+            Description = "Hugging Face repository ID (e.g., microsoft/Phi-4-mini-instruct-onnx)"
+        };
+
+        var filesArg = new Argument<string[]>("files")
+        {
+            Description = "Files to download, relative to the repo root",
+            Arity = ArgumentArity.ZeroOrMore
+        };
+
+        var outputOption = new Option<string?>("--output", "-o")
+        {
+            Description = "Local directory for downloaded files"
+        };
+
+        var revisionOption = new Option<string>("--revision", "-r")
+        {
+            Description = "Git revision — branch, tag, or commit SHA",
+            DefaultValueFactory = _ => "main"
+        };
+
+        var tokenOption = new Option<string?>("--token", "-t")
+        {
+            Description = "Hugging Face auth token (overrides HF_TOKEN env var)"
+        };
+
+        var optionalFlag = new Option<bool>("--optional")
+        {
+            Description = "Treat listed files as optional (skip failures instead of aborting)"
+        };
+
+        var noProgressFlag = new Option<bool>("--no-progress")
+        {
+            Description = "Suppress progress bar output"
+        };
+
+        var quietFlag = new Option<bool>("--quiet", "-q")
+        {
+            Description = "Minimal output (only errors)"
+        };
+
+        var command = new Command("download", "Download files from a Hugging Face repository");
+        command.Add(repoIdArg);
+        command.Add(filesArg);
+        command.Add(outputOption);
+        command.Add(revisionOption);
+        command.Add(tokenOption);
+        command.Add(optionalFlag);
+        command.Add(noProgressFlag);
+        command.Add(quietFlag);
+
+        command.SetAction(async (ParseResult parseResult, CancellationToken cancellationToken) =>
+        {
+            var repoId = parseResult.GetRequiredValue(repoIdArg);
+            var files = parseResult.GetValue(filesArg) ?? [];
+            var output = parseResult.GetValue(outputOption);
+            var revision = parseResult.GetValue(revisionOption) ?? "main";
+            var token = parseResult.GetValue(tokenOption);
+            var isOptional = parseResult.GetValue(optionalFlag);
+            var noProgress = parseResult.GetValue(noProgressFlag);
+            var quiet = parseResult.GetValue(quietFlag);
+
+            if (files.Length == 0)
+            {
+                AnsiConsole.MarkupLine("[red]Error:[/] At least one file must be specified.");
+                AnsiConsole.MarkupLine("[dim]Usage: hfdownload download <repo-id> file1 [[file2 ...]][/]");
+                return 1;
+            }
+
+            var localDir = output
+                ?? Path.Combine(
+                    DefaultPathHelper.GetDefaultCacheDirectory("hfdownload"),
+                    DefaultPathHelper.SanitizeModelName(repoId));
+
+            var options = new HuggingFaceDownloaderOptions
+            {
+                AuthToken = token,
+                ResolveFileSizesBeforeDownload = true
+            };
+
+            using var downloader = new HuggingFaceDownloader(options);
+
+            IReadOnlyList<string> requiredFiles = isOptional ? Array.Empty<string>() : files;
+            IReadOnlyList<string>? optionalFiles = isOptional ? files : null;
+
+            var stopwatch = Stopwatch.StartNew();
+
+            try
+            {
+                if (quiet)
+                {
+                    await RunSilentAsync(downloader, repoId, localDir, requiredFiles, optionalFiles, revision, cancellationToken);
+                }
+                else if (noProgress)
+                {
+                    await RunTextOnlyAsync(downloader, repoId, localDir, requiredFiles, optionalFiles, revision, cancellationToken);
+                }
+                else
+                {
+                    await RunWithProgressAsync(downloader, repoId, localDir, requiredFiles, optionalFiles, revision, cancellationToken);
+                }
+
+                stopwatch.Stop();
+
+                if (!quiet)
+                {
+                    AnsiConsole.WriteLine();
+                    AnsiConsole.MarkupLine($"[green]✓[/] Download complete for [bold]{Markup.Escape(repoId)}[/]");
+                    AnsiConsole.MarkupLine($"  [dim]Files:[/]  {files.Length}");
+                    AnsiConsole.MarkupLine($"  [dim]Dir:[/]    {Markup.Escape(localDir)}");
+                    AnsiConsole.MarkupLine($"  [dim]Time:[/]   {stopwatch.Elapsed:m\\:ss\\.ff}");
+                }
+
+                return 0;
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("Access denied"))
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+                AnsiConsole.MarkupLine("[yellow]Hint:[/] Set the [bold]HF_TOKEN[/] environment variable or use [bold]--token[/].");
+                return 1;
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("not found (404)"))
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+                AnsiConsole.MarkupLine("[yellow]Hint:[/] Check the repository ID and file names.");
+                return 1;
+            }
+            catch (InvalidOperationException ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+                return 1;
+            }
+            catch (OperationCanceledException)
+            {
+                AnsiConsole.MarkupLine("[yellow]Download cancelled.[/]");
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+                return 1;
+            }
+        });
+
+        return command;
+    }
+
+    private static async Task RunSilentAsync(
+        HuggingFaceDownloader downloader, string repoId, string localDir,
+        IReadOnlyList<string> requiredFiles, IReadOnlyList<string>? optionalFiles,
+        string revision, CancellationToken ct)
+    {
+        var request = new DownloadRequest
+        {
+            RepoId = repoId,
+            LocalDirectory = localDir,
+            RequiredFiles = requiredFiles,
+            OptionalFiles = optionalFiles,
+            Revision = revision
+        };
+
+        await downloader.DownloadFilesAsync(request, ct);
+    }
+
+    private static async Task RunTextOnlyAsync(
+        HuggingFaceDownloader downloader, string repoId, string localDir,
+        IReadOnlyList<string> requiredFiles, IReadOnlyList<string>? optionalFiles,
+        string revision, CancellationToken ct)
+    {
+        var progress = new Progress<DownloadProgress>(p =>
+        {
+            if (p.Message is not null)
+                AnsiConsole.MarkupLine($"[grey]{Markup.Escape(p.Message)}[/]");
+        });
+
+        var request = new DownloadRequest
+        {
+            RepoId = repoId,
+            LocalDirectory = localDir,
+            RequiredFiles = requiredFiles,
+            OptionalFiles = optionalFiles,
+            Revision = revision,
+            Progress = progress
+        };
+
+        await downloader.DownloadFilesAsync(request, ct);
+    }
+
+    private static async Task RunWithProgressAsync(
+        HuggingFaceDownloader downloader, string repoId, string localDir,
+        IReadOnlyList<string> requiredFiles, IReadOnlyList<string>? optionalFiles,
+        string revision, CancellationToken ct)
+    {
+        await AnsiConsole.Progress()
+            .AutoRefresh(true)
+            .AutoClear(false)
+            .HideCompleted(false)
+            .Columns(
+                new TaskDescriptionColumn(),
+                new ProgressBarColumn(),
+                new PercentageColumn(),
+                new SpinnerColumn())
+            .StartAsync(async ctx =>
+            {
+                var overallTask = ctx.AddTask($"[bold]{Markup.Escape(repoId)}[/]", maxValue: 100);
+                var fileTask = ctx.AddTask("Preparing...", maxValue: 100);
+
+                var progress = new Progress<DownloadProgress>(p =>
+                {
+                    overallTask.Value = Math.Min(p.PercentComplete, 100);
+
+                    switch (p.Stage)
+                    {
+                        case DownloadStage.Checking:
+                            fileTask.Description = Markup.Escape(p.Message ?? "Checking...");
+                            break;
+
+                        case DownloadStage.Downloading when p.CurrentFile is not null:
+                            fileTask.Description = $"[dim]{Markup.Escape(p.CurrentFile)}[/]";
+                            fileTask.Value = p.TotalBytes > 0
+                                ? Math.Min(p.PercentComplete, 100)
+                                : 0;
+                            break;
+
+                        case DownloadStage.Validating:
+                            fileTask.Description = "Validating...";
+                            fileTask.Value = 99;
+                            break;
+
+                        case DownloadStage.Complete:
+                            overallTask.Value = 100;
+                            fileTask.Value = 100;
+                            fileTask.Description = "[green]Done[/]";
+                            break;
+                    }
+                });
+
+                var request = new DownloadRequest
+                {
+                    RepoId = repoId,
+                    LocalDirectory = localDir,
+                    RequiredFiles = requiredFiles,
+                    OptionalFiles = optionalFiles,
+                    Revision = revision,
+                    Progress = progress
+                };
+
+                await downloader.DownloadFilesAsync(request, ct);
+            });
+    }
+}

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Commands/InfoCommand.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Commands/InfoCommand.cs
@@ -1,0 +1,101 @@
+using System.CommandLine;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ElBruno.HuggingFace;
+using ElBruno.HuggingFace.Cli.Services;
+using Spectre.Console;
+
+namespace ElBruno.HuggingFace.Cli.Commands;
+
+/// <summary>
+/// The <c>info</c> command — shows detailed information about a specific cached model.
+/// </summary>
+public static class InfoCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Creates the <c>info</c> <see cref="Command"/> with arguments, options, and handler.
+    /// </summary>
+    public static Command Create()
+    {
+        var repoIdArgument = new Argument<string>("repo-id")
+        {
+            Description = "Repository ID of the cached model (e.g. microsoft/phi-2)"
+        };
+
+        var cacheDirOption = new Option<string>("--cache-dir")
+        {
+            Description = "Cache directory to scan for downloaded models",
+            DefaultValueFactory = _ => DefaultPathHelper.GetDefaultCacheDirectory("hfdownload")
+        };
+
+        var formatOption = new Option<string>("--format")
+        {
+            Description = "Output format (table or json)",
+            DefaultValueFactory = _ => "table"
+        };
+        formatOption.AcceptOnlyFromAmong("table", "json");
+
+        var command = new Command("info", "Show details of a cached model");
+        command.Add(repoIdArgument);
+        command.Add(cacheDirOption);
+        command.Add(formatOption);
+
+        command.SetAction((parseResult, _) =>
+        {
+            var repoId = parseResult.GetValue(repoIdArgument)!;
+            var cacheDir = parseResult.GetValue(cacheDirOption)!;
+            var format = parseResult.GetValue(formatOption)!;
+
+            var manager = new CacheManager();
+            var model = manager.GetModelDetails(cacheDir, repoId);
+
+            if (model is null)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] Model [bold]{Markup.Escape(repoId)}[/] not found in {Markup.Escape(cacheDir)}");
+                return Task.FromResult(1);
+            }
+
+            if (format == "json")
+            {
+                var json = JsonSerializer.Serialize(model, JsonOptions);
+                Console.WriteLine(json);
+            }
+            else
+            {
+                AnsiConsole.MarkupLine($"[bold]Model:[/]  {Markup.Escape(model.Name)}");
+                AnsiConsole.MarkupLine($"[bold]Path:[/]   {Markup.Escape(model.FullPath)}");
+                AnsiConsole.MarkupLine($"[bold]Size:[/]   {ByteFormatHelper.FormatBytes(model.TotalSize)}");
+                AnsiConsole.MarkupLine($"[bold]Files:[/]  {model.FileCount}");
+                AnsiConsole.WriteLine();
+
+                if (model.Files.Count > 0)
+                {
+                    var table = new Table();
+                    table.AddColumn("File");
+                    table.AddColumn(new TableColumn("Size").RightAligned());
+                    table.AddColumn("Last Modified");
+
+                    foreach (var file in model.Files)
+                    {
+                        table.AddRow(
+                            Markup.Escape(file.RelativePath),
+                            ByteFormatHelper.FormatBytes(file.Size),
+                            file.LastModified.ToString("yyyy-MM-dd HH:mm"));
+                    }
+
+                    AnsiConsole.Write(table);
+                }
+            }
+
+            return Task.FromResult(0);
+        });
+
+        return command;
+    }
+}

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Commands/ListCommand.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Commands/ListCommand.cs
@@ -1,0 +1,87 @@
+using System.CommandLine;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ElBruno.HuggingFace;
+using ElBruno.HuggingFace.Cli.Services;
+using Spectre.Console;
+
+namespace ElBruno.HuggingFace.Cli.Commands;
+
+/// <summary>
+/// The <c>list</c> command — displays all cached models in the cache directory.
+/// </summary>
+public static class ListCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Creates the <c>list</c> <see cref="Command"/> with options and handler.
+    /// </summary>
+    public static Command Create()
+    {
+        var cacheDirOption = new Option<string>("--cache-dir")
+        {
+            Description = "Cache directory to scan for downloaded models",
+            DefaultValueFactory = _ => DefaultPathHelper.GetDefaultCacheDirectory("hfdownload")
+        };
+
+        var formatOption = new Option<string>("--format")
+        {
+            Description = "Output format (table or json)",
+            DefaultValueFactory = _ => "table"
+        };
+        formatOption.AcceptOnlyFromAmong("table", "json");
+
+        var command = new Command("list", "List downloaded models in the cache directory");
+        command.Add(cacheDirOption);
+        command.Add(formatOption);
+
+        command.SetAction((parseResult, _) =>
+        {
+            var cacheDir = parseResult.GetValue(cacheDirOption)!;
+            var format = parseResult.GetValue(formatOption)!;
+
+            var manager = new CacheManager();
+            var models = manager.GetCachedModels(cacheDir);
+
+            if (models.Count == 0)
+            {
+                AnsiConsole.MarkupLine($"[yellow]No cached models found in[/] {Markup.Escape(cacheDir)}");
+                return Task.FromResult(0);
+            }
+
+            if (format == "json")
+            {
+                var json = JsonSerializer.Serialize(models, JsonOptions);
+                Console.WriteLine(json);
+            }
+            else
+            {
+                var table = new Table();
+                table.AddColumn("Model");
+                table.AddColumn(new TableColumn("Files").RightAligned());
+                table.AddColumn(new TableColumn("Size").RightAligned());
+                table.AddColumn("Last Modified");
+
+                foreach (var model in models)
+                {
+                    table.AddRow(
+                        Markup.Escape(model.Name),
+                        model.FileCount.ToString(),
+                        ByteFormatHelper.FormatBytes(model.TotalSize),
+                        model.LastModified.ToString("yyyy-MM-dd HH:mm"));
+                }
+
+                AnsiConsole.Write(table);
+            }
+
+            return Task.FromResult(0);
+        });
+
+        return command;
+    }
+}

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Commands/PurgeCommand.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Commands/PurgeCommand.cs
@@ -1,0 +1,71 @@
+using System.CommandLine;
+using ElBruno.HuggingFace;
+using ElBruno.HuggingFace.Cli.Services;
+using Spectre.Console;
+
+namespace ElBruno.HuggingFace.Cli.Commands;
+
+/// <summary>
+/// The <c>purge</c> command — deletes all cached models from the cache directory.
+/// </summary>
+public static class PurgeCommand
+{
+    /// <summary>
+    /// Creates the <c>purge</c> <see cref="Command"/> with options and handler.
+    /// </summary>
+    public static Command Create()
+    {
+        var cacheDirOption = new Option<string>("--cache-dir")
+        {
+            Description = "Cache directory to purge",
+            DefaultValueFactory = _ => DefaultPathHelper.GetDefaultCacheDirectory("hfdownload")
+        };
+
+        var forceOption = new Option<bool>("--force", "-f")
+        {
+            Description = "Skip confirmation prompt"
+        };
+
+        var command = new Command("purge", "Delete all cached models");
+        command.Add(cacheDirOption);
+        command.Add(forceOption);
+
+        command.SetAction((parseResult, _) =>
+        {
+            var cacheDir = parseResult.GetValue(cacheDirOption)!;
+            var force = parseResult.GetValue(forceOption);
+
+            var manager = new CacheManager();
+            var models = manager.GetCachedModels(cacheDir);
+
+            if (models.Count == 0)
+            {
+                AnsiConsole.MarkupLine($"[yellow]No cached models found in[/] {Markup.Escape(cacheDir)}");
+                return Task.FromResult(0);
+            }
+
+            var totalFiles = models.Sum(m => m.FileCount);
+            var totalSize = models.Sum(m => m.TotalSize);
+
+            AnsiConsole.MarkupLine($"Models: [bold]{models.Count}[/]");
+            AnsiConsole.MarkupLine($"Files:  [bold]{totalFiles}[/]");
+            AnsiConsole.MarkupLine($"Size:   [bold]{ByteFormatHelper.FormatBytes(totalSize)}[/]");
+
+            if (!force)
+            {
+                if (!AnsiConsole.Confirm("This will delete ALL cached models. Are you sure?", defaultValue: false))
+                {
+                    AnsiConsole.MarkupLine("[yellow]Cancelled.[/]");
+                    return Task.FromResult(0);
+                }
+            }
+
+            var deletedCount = manager.PurgeAll(cacheDir);
+            AnsiConsole.MarkupLine(
+                $"[green]Purged[/] [bold]{deletedCount}[/] model(s) ({ByteFormatHelper.FormatBytes(totalSize)})");
+            return Task.FromResult(0);
+        });
+
+        return command;
+    }
+}

--- a/src/ElBruno.HuggingFace.Downloader.Cli/ElBruno.HuggingFace.Downloader.Cli.csproj
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/ElBruno.HuggingFace.Downloader.Cli.csproj
@@ -27,6 +27,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="ElBruno.HuggingFace.Downloader.Cli.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ElBruno.HuggingFace.Downloader\ElBruno.HuggingFace.Downloader.csproj" />
   </ItemGroup>
 

--- a/src/ElBruno.HuggingFace.Downloader.Cli/ElBruno.HuggingFace.Downloader.Cli.csproj
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/ElBruno.HuggingFace.Downloader.Cli.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>ElBruno.HuggingFace.Cli</RootNamespace>
+
+    <!-- Dotnet Tool Configuration -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>hfdownload</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+
+    <!-- NuGet Package Metadata -->
+    <PackageId>ElBruno.HuggingFace.Downloader.Cli</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Bruno Capuano</Authors>
+    <Description>A .NET CLI tool to download, manage, and inspect cached files from Hugging Face Hub repositories.</Description>
+    <PackageTags>huggingface;download;cli;dotnet-tool;onnx;model;ml;ai</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/elbruno/ElBruno.HuggingFace.Downloader</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/elbruno/ElBruno.HuggingFace.Downloader</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>logo_02.png</PackageIcon>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ElBruno.HuggingFace.Downloader\ElBruno.HuggingFace.Downloader.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
+    <PackageReference Include="Spectre.Console" Version="0.50.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\images\logo_02.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Models/CachedModel.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Models/CachedModel.cs
@@ -1,0 +1,40 @@
+namespace ElBruno.HuggingFace.Cli.Models;
+
+/// <summary>
+/// Represents metadata about a single file within a cached model directory.
+/// </summary>
+public sealed class CachedFileInfo
+{
+    /// <summary>Path of the file relative to the model directory.</summary>
+    public required string RelativePath { get; init; }
+
+    /// <summary>File size in bytes.</summary>
+    public required long Size { get; init; }
+
+    /// <summary>Last modification timestamp of the file.</summary>
+    public required DateTime LastModified { get; init; }
+}
+
+/// <summary>
+/// Represents a cached model directory with aggregate metadata and optional file details.
+/// </summary>
+public sealed class CachedModel
+{
+    /// <summary>Directory name (sanitized repo ID).</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Full path to the model's cache directory.</summary>
+    public required string FullPath { get; init; }
+
+    /// <summary>Total size of all files in bytes.</summary>
+    public required long TotalSize { get; init; }
+
+    /// <summary>Number of files in the model directory.</summary>
+    public required int FileCount { get; init; }
+
+    /// <summary>Most recent modification timestamp among all files.</summary>
+    public required DateTime LastModified { get; init; }
+
+    /// <summary>Detailed list of individual files (populated by GetModelDetails).</summary>
+    public IReadOnlyList<CachedFileInfo> Files { get; init; } = [];
+}

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Models/CliConfig.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Models/CliConfig.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace ElBruno.HuggingFace.Cli.Models;
+
+/// <summary>
+/// Persistent configuration for the hfdownload CLI tool.
+/// Stored as JSON in a platform-appropriate config directory.
+/// </summary>
+public sealed class CliConfig
+{
+    /// <summary>Default cache directory override. When <c>null</c>, uses the platform default.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CacheDirectory { get; set; }
+
+    /// <summary>Default Hugging Face auth token. When <c>null</c>, falls back to HF_TOKEN env var.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DefaultToken { get; set; }
+
+    /// <summary>Default Git revision for downloads.</summary>
+    public string DefaultRevision { get; set; } = "main";
+
+    /// <summary>Whether to suppress progress bars by default.</summary>
+    public bool NoProgress { get; set; }
+
+    /// <summary>Known configuration keys and their descriptions.</summary>
+    public static IReadOnlyDictionary<string, string> KnownKeys { get; } = new Dictionary<string, string>
+    {
+        ["cache-dir"] = "Default cache directory (overrides platform default)",
+        ["default-token"] = "Default Hugging Face auth token",
+        ["default-revision"] = "Default Git revision for downloads (default: main)",
+        ["no-progress"] = "Suppress progress bars by default (true/false)",
+    };
+}

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Program.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Program.cs
@@ -1,0 +1,30 @@
+using System.CommandLine;
+
+var rootCommand = new RootCommand(
+    "HuggingFace Downloader CLI — download, manage, and inspect cached models from Hugging Face Hub.");
+
+Command[] subcommands =
+[
+    new("download", "Download files from a Hugging Face repository"),
+    new("check", "Check if files exist in the local cache"),
+    new("list", "List downloaded models in the cache directory"),
+    new("info", "Show details of a cached model"),
+    new("delete", "Delete a cached model and all its files"),
+    new("delete-file", "Delete a single file from a cached model"),
+    new("purge", "Delete all cached models"),
+    new("config", "Show or modify configuration"),
+];
+
+foreach (var command in subcommands)
+{
+    var name = command.Name;
+    command.SetAction(_ =>
+    {
+        Console.WriteLine($"[{name}] Not yet implemented.");
+    });
+
+    rootCommand.Add(command);
+}
+
+var config = new CommandLineConfiguration(rootCommand);
+return await config.InvokeAsync(args);

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Program.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Program.cs
@@ -1,30 +1,24 @@
 using System.CommandLine;
+using ElBruno.HuggingFace.Cli.Commands;
 
 var rootCommand = new RootCommand(
     "HuggingFace Downloader CLI — download, manage, and inspect cached models from Hugging Face Hub.");
 
-Command[] subcommands =
-[
-    new("download", "Download files from a Hugging Face repository"),
-    new("check", "Check if files exist in the local cache"),
-    new("list", "List downloaded models in the cache directory"),
-    new("info", "Show details of a cached model"),
-    new("delete", "Delete a cached model and all its files"),
-    new("delete-file", "Delete a single file from a cached model"),
-    new("purge", "Delete all cached models"),
-    new("config", "Show or modify configuration"),
-];
+// Download & check commands (Phase 2)
+rootCommand.Add(DownloadCommand.Create());
+rootCommand.Add(CheckCommand.Create());
 
-foreach (var command in subcommands)
-{
-    var name = command.Name;
-    command.SetAction(_ =>
-    {
-        Console.WriteLine($"[{name}] Not yet implemented.");
-    });
+// Cache management commands (Phase 3)
+rootCommand.Add(ListCommand.Create());
+rootCommand.Add(InfoCommand.Create());
+rootCommand.Add(DeleteCommand.Create());
+rootCommand.Add(DeleteFileCommand.Create());
+rootCommand.Add(PurgeCommand.Create());
 
-    rootCommand.Add(command);
-}
+// Stub commands (deferred)
+var configStub = new Command("config", "Show or modify configuration");
+configStub.SetAction(_ => Console.WriteLine("[config] Not yet implemented."));
+rootCommand.Add(configStub);
 
 var config = new CommandLineConfiguration(rootCommand);
 return await config.InvokeAsync(args);

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Program.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Program.cs
@@ -4,21 +4,19 @@ using ElBruno.HuggingFace.Cli.Commands;
 var rootCommand = new RootCommand(
     "HuggingFace Downloader CLI — download, manage, and inspect cached models from Hugging Face Hub.");
 
-// Download & check commands (Phase 2)
+// Download & check commands
 rootCommand.Add(DownloadCommand.Create());
 rootCommand.Add(CheckCommand.Create());
 
-// Cache management commands (Phase 3)
+// Cache management commands
 rootCommand.Add(ListCommand.Create());
 rootCommand.Add(InfoCommand.Create());
 rootCommand.Add(DeleteCommand.Create());
 rootCommand.Add(DeleteFileCommand.Create());
 rootCommand.Add(PurgeCommand.Create());
 
-// Stub commands (deferred)
-var configStub = new Command("config", "Show or modify configuration");
-configStub.SetAction(_ => Console.WriteLine("[config] Not yet implemented."));
-rootCommand.Add(configStub);
+// Configuration commands
+rootCommand.Add(ConfigCommand.Create());
 
 var config = new CommandLineConfiguration(rootCommand);
 return await config.InvokeAsync(args);

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Services/CacheManager.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Services/CacheManager.cs
@@ -1,0 +1,178 @@
+using ElBruno.HuggingFace;
+using ElBruno.HuggingFace.Cli.Models;
+
+namespace ElBruno.HuggingFace.Cli.Services;
+
+/// <summary>
+/// Scans and manages the local cache directory for downloaded Hugging Face models.
+/// Convention: each immediate subdirectory of the cache root represents one model.
+/// </summary>
+public sealed class CacheManager
+{
+    /// <summary>
+    /// Returns aggregate metadata for every cached model in the cache directory.
+    /// </summary>
+    public IReadOnlyList<CachedModel> GetCachedModels(string cacheDir)
+    {
+        if (!Directory.Exists(cacheDir))
+            return [];
+
+        var models = new List<CachedModel>();
+
+        foreach (var dir in Directory.EnumerateDirectories(cacheDir))
+        {
+            var info = BuildCachedModel(dir, includeFiles: false);
+            if (info is not null)
+                models.Add(info);
+        }
+
+        return models;
+    }
+
+    /// <summary>
+    /// Returns detailed metadata for a specific cached model, including per-file information.
+    /// </summary>
+    public CachedModel? GetModelDetails(string cacheDir, string repoId)
+    {
+        var modelPath = ResolveModelPath(cacheDir, repoId);
+        if (modelPath is null || !Directory.Exists(modelPath))
+            return null;
+
+        return BuildCachedModel(modelPath, includeFiles: true);
+    }
+
+    /// <summary>
+    /// Deletes all files and subdirectories for the specified model.
+    /// </summary>
+    /// <returns><c>true</c> if the model directory was found and deleted; otherwise <c>false</c>.</returns>
+    public bool DeleteModel(string cacheDir, string repoId)
+    {
+        var modelPath = ResolveModelPath(cacheDir, repoId);
+        if (modelPath is null || !Directory.Exists(modelPath))
+            return false;
+
+        Directory.Delete(modelPath, recursive: true);
+        return true;
+    }
+
+    /// <summary>
+    /// Deletes a single file from a cached model directory.
+    /// </summary>
+    /// <returns><c>true</c> if the file was found and deleted; otherwise <c>false</c>.</returns>
+    public bool DeleteFile(string cacheDir, string repoId, string filePath)
+    {
+        var modelPath = ResolveModelPath(cacheDir, repoId);
+        if (modelPath is null || !Directory.Exists(modelPath))
+            return false;
+
+        var fullPath = Path.GetFullPath(Path.Combine(modelPath, filePath));
+
+        // Prevent path traversal
+        if (!fullPath.StartsWith(Path.GetFullPath(modelPath), StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (!File.Exists(fullPath))
+            return false;
+
+        File.Delete(fullPath);
+        return true;
+    }
+
+    /// <summary>
+    /// Deletes the entire cache directory contents.
+    /// </summary>
+    /// <returns>The number of model directories deleted.</returns>
+    public int PurgeAll(string cacheDir)
+    {
+        if (!Directory.Exists(cacheDir))
+            return 0;
+
+        var dirs = Directory.GetDirectories(cacheDir);
+        foreach (var dir in dirs)
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+
+        // Also delete any loose files at the root level
+        foreach (var file in Directory.GetFiles(cacheDir))
+        {
+            File.Delete(file);
+        }
+
+        return dirs.Length;
+    }
+
+    /// <summary>
+    /// Resolves a repo ID to a directory path inside the cache, checking both the sanitized
+    /// name and a direct match.
+    /// </summary>
+    private static string? ResolveModelPath(string cacheDir, string repoId)
+    {
+        if (!Directory.Exists(cacheDir))
+            return null;
+
+        // Try sanitized name first (e.g. "microsoft/phi-2" → "microsoft_phi-2")
+        var sanitized = DefaultPathHelper.SanitizeModelName(repoId);
+        var sanitizedPath = Path.Combine(cacheDir, sanitized);
+        if (Directory.Exists(sanitizedPath))
+            return sanitizedPath;
+
+        // Fall back to direct name match (in case the dir was named without sanitization)
+        var directPath = Path.Combine(cacheDir, repoId);
+        if (Directory.Exists(directPath))
+            return directPath;
+
+        return null;
+    }
+
+    private static CachedModel? BuildCachedModel(string modelDir, bool includeFiles)
+    {
+        var dirInfo = new DirectoryInfo(modelDir);
+        var allFiles = dirInfo.GetFiles("*", SearchOption.AllDirectories);
+
+        if (allFiles.Length == 0 && !includeFiles)
+        {
+            // Still report empty directories
+            return new CachedModel
+            {
+                Name = dirInfo.Name,
+                FullPath = dirInfo.FullName,
+                TotalSize = 0,
+                FileCount = 0,
+                LastModified = dirInfo.LastWriteTime,
+                Files = [],
+            };
+        }
+
+        long totalSize = 0;
+        var lastModified = dirInfo.LastWriteTime;
+        var fileInfos = new List<CachedFileInfo>(allFiles.Length);
+
+        foreach (var file in allFiles)
+        {
+            totalSize += file.Length;
+            if (file.LastWriteTime > lastModified)
+                lastModified = file.LastWriteTime;
+
+            if (includeFiles)
+            {
+                fileInfos.Add(new CachedFileInfo
+                {
+                    RelativePath = Path.GetRelativePath(dirInfo.FullName, file.FullName),
+                    Size = file.Length,
+                    LastModified = file.LastWriteTime,
+                });
+            }
+        }
+
+        return new CachedModel
+        {
+            Name = dirInfo.Name,
+            FullPath = dirInfo.FullName,
+            TotalSize = totalSize,
+            FileCount = allFiles.Length,
+            LastModified = lastModified,
+            Files = includeFiles ? fileInfos : [],
+        };
+    }
+}

--- a/src/ElBruno.HuggingFace.Downloader.Cli/Services/ConfigManager.cs
+++ b/src/ElBruno.HuggingFace.Downloader.Cli/Services/ConfigManager.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using ElBruno.HuggingFace.Cli.Models;
+
+namespace ElBruno.HuggingFace.Cli.Services;
+
+/// <summary>
+/// Manages persistent CLI configuration stored as a JSON file in the
+/// platform-appropriate config directory.
+/// </summary>
+public sealed class ConfigManager
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    /// <summary>
+    /// Gets the directory where the config file is stored.
+    /// Windows: %APPDATA%\hfdownload, Linux/macOS: ~/.config/hfdownload
+    /// </summary>
+    public static string GetConfigDirectory()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "hfdownload");
+        }
+
+        // Linux/macOS — respect XDG_CONFIG_HOME if set
+        var xdgConfig = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        if (!string.IsNullOrEmpty(xdgConfig))
+        {
+            return Path.Combine(xdgConfig, "hfdownload");
+        }
+
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".config", "hfdownload");
+    }
+
+    /// <summary>Gets the full path to the config file.</summary>
+    public static string GetConfigPath() => Path.Combine(GetConfigDirectory(), "config.json");
+
+    /// <summary>Loads the current configuration, returning defaults if no config file exists.</summary>
+    public CliConfig Load()
+    {
+        var path = GetConfigPath();
+        if (!File.Exists(path))
+            return new CliConfig();
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize<CliConfig>(json) ?? new CliConfig();
+        }
+        catch (JsonException)
+        {
+            return new CliConfig();
+        }
+    }
+
+    /// <summary>Saves the configuration to disk, creating the directory if needed.</summary>
+    public void Save(CliConfig config)
+    {
+        var path = GetConfigPath();
+        var dir = Path.GetDirectoryName(path)!;
+
+        if (!Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        var json = JsonSerializer.Serialize(config, JsonOptions);
+        File.WriteAllText(path, json);
+    }
+
+    /// <summary>Resets the configuration by deleting the config file.</summary>
+    /// <returns><c>true</c> if the file existed and was deleted.</returns>
+    public bool Reset()
+    {
+        var path = GetConfigPath();
+        if (!File.Exists(path))
+            return false;
+
+        File.Delete(path);
+        return true;
+    }
+
+    /// <summary>
+    /// Sets a single configuration value by key.
+    /// Returns <c>true</c> if the key was recognized and set; <c>false</c> otherwise.
+    /// </summary>
+    public bool SetValue(CliConfig config, string key, string value)
+    {
+        switch (key.ToLowerInvariant())
+        {
+            case "cache-dir":
+                config.CacheDirectory = string.IsNullOrWhiteSpace(value) ? null : value;
+                return true;
+
+            case "default-token":
+                config.DefaultToken = string.IsNullOrWhiteSpace(value) ? null : value;
+                return true;
+
+            case "default-revision":
+                config.DefaultRevision = string.IsNullOrWhiteSpace(value) ? "main" : value;
+                return true;
+
+            case "no-progress":
+                if (bool.TryParse(value, out var noProgress))
+                {
+                    config.NoProgress = noProgress;
+                    return true;
+                }
+                return false;
+
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets a single configuration value by key, or <c>null</c> if unrecognized.
+    /// </summary>
+    public static string? GetValue(CliConfig config, string key)
+    {
+        return key.ToLowerInvariant() switch
+        {
+            "cache-dir" => config.CacheDirectory ?? "(platform default)",
+            "default-token" => config.DefaultToken is not null ? "****" : "(not set)",
+            "default-revision" => config.DefaultRevision,
+            "no-progress" => config.NoProgress.ToString().ToLowerInvariant(),
+            _ => null,
+        };
+    }
+}

--- a/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/CacheManagerEdgeCaseTests.cs
+++ b/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/CacheManagerEdgeCaseTests.cs
@@ -1,0 +1,188 @@
+using Xunit;
+using ElBruno.HuggingFace.Cli.Services;
+
+namespace ElBruno.HuggingFace.Cli.Tests;
+
+/// <summary>
+/// Edge case tests for <see cref="CacheManager"/> — nested dirs, sanitized names, loose files.
+/// </summary>
+public sealed class CacheManagerEdgeCaseTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly CacheManager _manager;
+
+    public CacheManagerEdgeCaseTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(_tempDir);
+        _manager = new CacheManager();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ── GetCachedModels with nested subdirectories ──────────────────
+
+    [Fact]
+    public void GetCachedModels_NestedSubdirectories_CountsAllNestedFiles()
+    {
+        var modelDir = Path.Combine(_tempDir, "nested-model");
+        Directory.CreateDirectory(modelDir);
+        File.WriteAllBytes(Path.Combine(modelDir, "root.bin"), new byte[100]);
+
+        var subDir = Path.Combine(modelDir, "subdir");
+        Directory.CreateDirectory(subDir);
+        File.WriteAllBytes(Path.Combine(subDir, "nested.bin"), new byte[200]);
+
+        var result = _manager.GetCachedModels(_tempDir);
+
+        var model = Assert.Single(result);
+        Assert.Equal(2, model.FileCount);
+        Assert.Equal(300, model.TotalSize);
+    }
+
+    // ── GetModelDetails resolves sanitized repo ID ──────────────────
+
+    [Fact]
+    public void GetModelDetails_SanitizedRepoId_ResolvesCorrectly()
+    {
+        // "microsoft/phi-2" sanitizes to "microsoft_phi-2"
+        TestHelpers.CreateModelDir(_tempDir, "microsoft_phi-2", ("model.bin", 500));
+
+        var result = _manager.GetModelDetails(_tempDir, "microsoft/phi-2");
+
+        Assert.NotNull(result);
+        Assert.Equal("microsoft_phi-2", result.Name);
+    }
+
+    [Fact]
+    public void GetModelDetails_DirectNameFallback_WhenSanitizedDoesntMatch()
+    {
+        // Directory already named "my-model" (not via sanitization)
+        TestHelpers.CreateModelDir(_tempDir, "my-model", ("data.bin", 50));
+
+        var result = _manager.GetModelDetails(_tempDir, "my-model");
+
+        Assert.NotNull(result);
+        Assert.Equal("my-model", result.Name);
+    }
+
+    // ── DeleteModel with deeply nested structure ────────────────────
+
+    [Fact]
+    public void DeleteModel_DeeplyNestedStructure_RemovesEverything()
+    {
+        var modelDir = Path.Combine(_tempDir, "deep-model");
+        var deepPath = Path.Combine(modelDir, "a", "b", "c");
+        Directory.CreateDirectory(deepPath);
+        File.WriteAllBytes(Path.Combine(deepPath, "deep.bin"), new byte[10]);
+        File.WriteAllBytes(Path.Combine(modelDir, "top.bin"), new byte[20]);
+
+        var result = _manager.DeleteModel(_tempDir, "deep-model");
+
+        Assert.True(result);
+        Assert.False(Directory.Exists(modelDir));
+    }
+
+    // ── DeleteFile with nested subdirectory file ────────────────────
+
+    [Fact]
+    public void DeleteFile_NestedSubdirectoryFile_DeletesCorrectly()
+    {
+        var modelDir = Path.Combine(_tempDir, "nested-del");
+        var subDir = Path.Combine(modelDir, "subdir");
+        Directory.CreateDirectory(subDir);
+        File.WriteAllBytes(Path.Combine(subDir, "weights.bin"), new byte[100]);
+        File.WriteAllBytes(Path.Combine(modelDir, "config.json"), new byte[50]);
+
+        var result = _manager.DeleteFile(_tempDir, "nested-del", Path.Combine("subdir", "weights.bin"));
+
+        Assert.True(result);
+        Assert.False(File.Exists(Path.Combine(subDir, "weights.bin")));
+        Assert.True(File.Exists(Path.Combine(modelDir, "config.json")));
+    }
+
+    // ── PurgeAll removes loose files at cache root ──────────────────
+
+    [Fact]
+    public void PurgeAll_RemovesLooseFilesAtCacheRoot()
+    {
+        TestHelpers.CreateModelDir(_tempDir, "model-x", ("a.bin", 10));
+        File.WriteAllBytes(Path.Combine(_tempDir, "stray-file.txt"), new byte[5]);
+
+        _manager.PurgeAll(_tempDir);
+
+        Assert.Empty(Directory.GetDirectories(_tempDir));
+        Assert.Empty(Directory.GetFiles(_tempDir));
+    }
+
+    // ── GetCachedModels LastModified from most recent file ──────────
+
+    [Fact]
+    public void GetCachedModels_LastModified_ReflectsMostRecentFile()
+    {
+        var modelDir = Path.Combine(_tempDir, "time-model");
+        Directory.CreateDirectory(modelDir);
+
+        var oldFile = Path.Combine(modelDir, "old.bin");
+        File.WriteAllBytes(oldFile, new byte[10]);
+        File.SetLastWriteTime(oldFile, new DateTime(2020, 1, 1));
+
+        var newFile = Path.Combine(modelDir, "new.bin");
+        File.WriteAllBytes(newFile, new byte[20]);
+        var expectedTime = new DateTime(2025, 6, 15, 12, 0, 0);
+        File.SetLastWriteTime(newFile, expectedTime);
+
+        // Set directory time older so file time wins
+        Directory.SetLastWriteTime(modelDir, new DateTime(2019, 1, 1));
+
+        var result = _manager.GetCachedModels(_tempDir);
+
+        var model = Assert.Single(result);
+        Assert.Equal(expectedTime, model.LastModified);
+    }
+
+    // ── CachedModel.Files includes nested files with relative paths ─
+
+    [Fact]
+    public void GetModelDetails_NestedFiles_HaveProperRelativePaths()
+    {
+        var modelDir = Path.Combine(_tempDir, "rel-path-model");
+        Directory.CreateDirectory(modelDir);
+        File.WriteAllBytes(Path.Combine(modelDir, "root.bin"), new byte[10]);
+
+        var sub = Path.Combine(modelDir, "sub");
+        Directory.CreateDirectory(sub);
+        File.WriteAllBytes(Path.Combine(sub, "nested.bin"), new byte[20]);
+
+        var result = _manager.GetModelDetails(_tempDir, "rel-path-model");
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Files.Count);
+        Assert.Contains(result.Files, f => f.RelativePath == "root.bin");
+        Assert.Contains(result.Files, f => f.RelativePath == Path.Combine("sub", "nested.bin"));
+    }
+
+    // ── Multiple models with same file names in different dirs ──────
+
+    [Fact]
+    public void GetCachedModels_MultipleModels_SameFileNames_IndependentMetrics()
+    {
+        TestHelpers.CreateModelDir(_tempDir, "model-alpha", ("weights.bin", 100), ("config.json", 50));
+        TestHelpers.CreateModelDir(_tempDir, "model-beta", ("weights.bin", 200), ("config.json", 75));
+
+        var result = _manager.GetCachedModels(_tempDir);
+
+        Assert.Equal(2, result.Count);
+        var alpha = result.First(m => m.Name == "model-alpha");
+        var beta = result.First(m => m.Name == "model-beta");
+
+        Assert.Equal(150, alpha.TotalSize);
+        Assert.Equal(275, beta.TotalSize);
+        Assert.Equal(2, alpha.FileCount);
+        Assert.Equal(2, beta.FileCount);
+    }
+}

--- a/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/CacheManagerTests.cs
+++ b/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/CacheManagerTests.cs
@@ -1,0 +1,263 @@
+using Xunit;
+using ElBruno.HuggingFace.Cli.Services;
+
+namespace ElBruno.HuggingFace.Cli.Tests;
+
+/// <summary>
+/// Tests for <see cref="CacheManager"/> — cache scanning, deletion, model enumeration.
+/// </summary>
+public sealed class CacheManagerTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly CacheManager _manager;
+
+    public CacheManagerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(_tempDir);
+        _manager = new CacheManager();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ── GetCachedModels ─────────────────────────────────────────────
+
+    [Fact]
+    public void GetCachedModels_NonExistentDirectory_ReturnsEmptyList()
+    {
+        var nonExistent = Path.Combine(_tempDir, "does-not-exist");
+
+        var result = _manager.GetCachedModels(nonExistent);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetCachedModels_EmptyDirectory_ReturnsEmptyList()
+    {
+        var result = _manager.GetCachedModels(_tempDir);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetCachedModels_PopulatedDirectory_ReturnsModels()
+    {
+        CreateModelDir("model-a", ("weights.bin", 100));
+        CreateModelDir("model-b", ("config.json", 50), ("tokenizer.json", 75));
+
+        var result = _manager.GetCachedModels(_tempDir);
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, m => m.Name == "model-a");
+        Assert.Contains(result, m => m.Name == "model-b");
+    }
+
+    [Fact]
+    public void GetCachedModels_CalculatesTotalSizeCorrectly()
+    {
+        CreateModelDir("model-x", ("a.bin", 1024), ("b.bin", 2048));
+
+        var result = _manager.GetCachedModels(_tempDir);
+
+        var model = Assert.Single(result);
+        Assert.Equal(1024 + 2048, model.TotalSize);
+        Assert.Equal(2, model.FileCount);
+    }
+
+    [Fact]
+    public void GetCachedModels_EmptyModelDirectory_ReportsZeroSize()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempDir, "empty-model"));
+
+        var result = _manager.GetCachedModels(_tempDir);
+
+        var model = Assert.Single(result);
+        Assert.Equal(0, model.TotalSize);
+        Assert.Equal(0, model.FileCount);
+    }
+
+    // ── GetModelDetails ─────────────────────────────────────────────
+
+    [Fact]
+    public void GetModelDetails_NonExistentModel_ReturnsNull()
+    {
+        var result = _manager.GetModelDetails(_tempDir, "no-such-model");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetModelDetails_ExistingModel_ReturnsDetailedFileInfo()
+    {
+        CreateModelDir("microsoft_phi-2", ("model.onnx", 500), ("config.json", 30));
+
+        var result = _manager.GetModelDetails(_tempDir, "microsoft_phi-2");
+
+        Assert.NotNull(result);
+        Assert.Equal("microsoft_phi-2", result.Name);
+        Assert.Equal(2, result.FileCount);
+        Assert.Equal(530, result.TotalSize);
+        Assert.Equal(2, result.Files.Count);
+        Assert.Contains(result.Files, f => f.RelativePath == "model.onnx");
+        Assert.Contains(result.Files, f => f.RelativePath == "config.json");
+    }
+
+    [Fact]
+    public void GetModelDetails_ReportsCorrectFileSizes()
+    {
+        CreateModelDir("size-test", ("big.bin", 4096));
+
+        var result = _manager.GetModelDetails(_tempDir, "size-test");
+
+        Assert.NotNull(result);
+        var file = Assert.Single(result.Files);
+        Assert.Equal(4096, file.Size);
+    }
+
+    // ── DeleteModel ─────────────────────────────────────────────────
+
+    [Fact]
+    public void DeleteModel_NonExistentModel_ReturnsFalse()
+    {
+        var result = _manager.DeleteModel(_tempDir, "phantom-model");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void DeleteModel_ExistingModel_RemovesDirectoryAndReturnsTrue()
+    {
+        CreateModelDir("doomed-model", ("file.bin", 10));
+
+        var result = _manager.DeleteModel(_tempDir, "doomed-model");
+
+        Assert.True(result);
+        Assert.False(Directory.Exists(Path.Combine(_tempDir, "doomed-model")));
+    }
+
+    [Fact]
+    public void DeleteModel_AfterDeletion_GetModelDetailsReturnsNull()
+    {
+        CreateModelDir("transient", ("data.bin", 10));
+        _manager.DeleteModel(_tempDir, "transient");
+
+        var result = _manager.GetModelDetails(_tempDir, "transient");
+
+        Assert.Null(result);
+    }
+
+    // ── DeleteFile ──────────────────────────────────────────────────
+
+    [Fact]
+    public void DeleteFile_ExistingFile_RemovesFileAndReturnsTrue()
+    {
+        CreateModelDir("my-model", ("keep.txt", 10), ("remove.txt", 20));
+
+        var result = _manager.DeleteFile(_tempDir, "my-model", "remove.txt");
+
+        Assert.True(result);
+        Assert.False(File.Exists(Path.Combine(_tempDir, "my-model", "remove.txt")));
+        Assert.True(File.Exists(Path.Combine(_tempDir, "my-model", "keep.txt")));
+    }
+
+    [Fact]
+    public void DeleteFile_NonExistentFile_ReturnsFalse()
+    {
+        CreateModelDir("sparse-model", ("only.txt", 10));
+
+        var result = _manager.DeleteFile(_tempDir, "sparse-model", "ghost.txt");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void DeleteFile_NonExistentModel_ReturnsFalse()
+    {
+        var result = _manager.DeleteFile(_tempDir, "no-model", "file.txt");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void DeleteFile_PathTraversal_ReturnsFalse()
+    {
+        CreateModelDir("safe-model", ("legit.txt", 10));
+
+        var result = _manager.DeleteFile(_tempDir, "safe-model", "../../etc/passwd");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void DeleteFile_PathTraversalWithBackslash_ReturnsFalse()
+    {
+        CreateModelDir("safe-model2", ("legit.txt", 10));
+
+        var result = _manager.DeleteFile(_tempDir, "safe-model2", @"..\..\windows\system32\config");
+
+        Assert.False(result);
+    }
+
+    // ── PurgeAll ────────────────────────────────────────────────────
+
+    [Fact]
+    public void PurgeAll_EmptyDirectory_ReturnsZero()
+    {
+        var result = _manager.PurgeAll(_tempDir);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void PurgeAll_NonExistentDirectory_ReturnsZero()
+    {
+        var nonExistent = Path.Combine(_tempDir, "nope");
+
+        var result = _manager.PurgeAll(nonExistent);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void PurgeAll_MultipleModels_RemovesAllAndReturnsCount()
+    {
+        CreateModelDir("alpha", ("a.bin", 10));
+        CreateModelDir("beta", ("b.bin", 20));
+        CreateModelDir("gamma", ("c.bin", 30));
+
+        var result = _manager.PurgeAll(_tempDir);
+
+        Assert.Equal(3, result);
+        Assert.Empty(Directory.GetDirectories(_tempDir));
+    }
+
+    [Fact]
+    public void PurgeAll_AfterPurge_GetCachedModelsReturnsEmpty()
+    {
+        CreateModelDir("ephemeral", ("data.bin", 10));
+        _manager.PurgeAll(_tempDir);
+
+        var models = _manager.GetCachedModels(_tempDir);
+
+        Assert.Empty(models);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private void CreateModelDir(string name, params (string fileName, int size)[] files)
+    {
+        var modelDir = Path.Combine(_tempDir, name);
+        Directory.CreateDirectory(modelDir);
+
+        foreach (var (fileName, size) in files)
+        {
+            var filePath = Path.Combine(modelDir, fileName);
+            File.WriteAllBytes(filePath, new byte[size]);
+        }
+    }
+}

--- a/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/CachedModelTests.cs
+++ b/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/CachedModelTests.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+using ElBruno.HuggingFace.Cli.Models;
+
+namespace ElBruno.HuggingFace.Cli.Tests;
+
+/// <summary>
+/// Tests for <see cref="CachedModel"/> and <see cref="CachedFileInfo"/> serialization and defaults.
+/// </summary>
+public sealed class CachedModelTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void CachedModel_SerializesToJson_Correctly()
+    {
+        var model = new CachedModel
+        {
+            Name = "test-model",
+            FullPath = @"C:\cache\test-model",
+            TotalSize = 1024,
+            FileCount = 2,
+            LastModified = new DateTime(2024, 1, 15, 10, 30, 0),
+            Files =
+            [
+                new CachedFileInfo
+                {
+                    RelativePath = "weights.bin",
+                    Size = 900,
+                    LastModified = new DateTime(2024, 1, 15, 10, 30, 0),
+                },
+                new CachedFileInfo
+                {
+                    RelativePath = "config.json",
+                    Size = 124,
+                    LastModified = new DateTime(2024, 1, 14, 8, 0, 0),
+                },
+            ],
+        };
+
+        var json = JsonSerializer.Serialize(model, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<CachedModel>(json, JsonOptions);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal("test-model", deserialized.Name);
+        Assert.Equal(1024, deserialized.TotalSize);
+        Assert.Equal(2, deserialized.FileCount);
+        Assert.Equal(2, deserialized.Files.Count);
+    }
+
+    [Fact]
+    public void CachedFileInfo_SerializesToJson_Correctly()
+    {
+        var fileInfo = new CachedFileInfo
+        {
+            RelativePath = "subdir/model.onnx",
+            Size = 4096,
+            LastModified = new DateTime(2024, 3, 10, 14, 0, 0),
+        };
+
+        var json = JsonSerializer.Serialize(fileInfo, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<CachedFileInfo>(json, JsonOptions);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal("subdir/model.onnx", deserialized.RelativePath);
+        Assert.Equal(4096, deserialized.Size);
+    }
+
+    [Fact]
+    public void CachedModel_EmptyFilesList_SerializesCorrectly()
+    {
+        var model = new CachedModel
+        {
+            Name = "empty-model",
+            FullPath = @"C:\cache\empty-model",
+            TotalSize = 0,
+            FileCount = 0,
+            LastModified = DateTime.MinValue,
+            Files = [],
+        };
+
+        var json = JsonSerializer.Serialize(model, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<CachedModel>(json, JsonOptions);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal("empty-model", deserialized.Name);
+        Assert.Empty(deserialized.Files);
+    }
+
+    [Fact]
+    public void CachedModel_DefaultFiles_IsEmptyList()
+    {
+        var model = new CachedModel
+        {
+            Name = "default-files",
+            FullPath = @"C:\cache\default-files",
+            TotalSize = 0,
+            FileCount = 0,
+            LastModified = DateTime.MinValue,
+        };
+
+        Assert.NotNull(model.Files);
+        Assert.Empty(model.Files);
+    }
+}

--- a/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/CliConfigTests.cs
+++ b/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/CliConfigTests.cs
@@ -1,0 +1,68 @@
+using Xunit;
+using ElBruno.HuggingFace.Cli.Models;
+
+namespace ElBruno.HuggingFace.Cli.Tests;
+
+/// <summary>
+/// Tests for <see cref="CliConfig"/> — known keys and default values.
+/// </summary>
+public sealed class CliConfigTests
+{
+    [Fact]
+    public void KnownKeys_ContainsExpectedKeys()
+    {
+        var keys = CliConfig.KnownKeys;
+
+        Assert.Contains("cache-dir", keys.Keys);
+        Assert.Contains("default-token", keys.Keys);
+        Assert.Contains("default-revision", keys.Keys);
+        Assert.Contains("no-progress", keys.Keys);
+    }
+
+    [Fact]
+    public void KnownKeys_HasExactlyFourEntries()
+    {
+        Assert.Equal(4, CliConfig.KnownKeys.Count);
+    }
+
+    [Fact]
+    public void KnownKeys_AllHaveNonEmptyDescriptions()
+    {
+        foreach (var (key, description) in CliConfig.KnownKeys)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(description), $"Key '{key}' has empty description");
+        }
+    }
+
+    [Fact]
+    public void DefaultValues_CacheDirectoryIsNull()
+    {
+        var config = new CliConfig();
+
+        Assert.Null(config.CacheDirectory);
+    }
+
+    [Fact]
+    public void DefaultValues_DefaultTokenIsNull()
+    {
+        var config = new CliConfig();
+
+        Assert.Null(config.DefaultToken);
+    }
+
+    [Fact]
+    public void DefaultValues_DefaultRevisionIsMain()
+    {
+        var config = new CliConfig();
+
+        Assert.Equal("main", config.DefaultRevision);
+    }
+
+    [Fact]
+    public void DefaultValues_NoProgressIsFalse()
+    {
+        var config = new CliConfig();
+
+        Assert.False(config.NoProgress);
+    }
+}

--- a/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/CommandExecutionTests.cs
+++ b/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/CommandExecutionTests.cs
@@ -1,0 +1,289 @@
+using System.CommandLine;
+using Xunit;
+
+namespace ElBruno.HuggingFace.Cli.Tests;
+
+/// <summary>
+/// End-to-end tests that invoke CLI commands through System.CommandLine
+/// and verify exit codes and filesystem side effects.
+/// </summary>
+[Collection("ConfigFile")]
+public sealed class CommandExecutionTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public CommandExecutionTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private static async Task<int> InvokeAsync(params string[] args)
+    {
+        var root = TestHelpers.BuildRootCommand();
+        var config = new CommandLineConfiguration(root);
+        return await config.InvokeAsync(args);
+    }
+
+    // ── Check command E2E ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Check_AllFilesPresent_ReturnsZero()
+    {
+        var outputDir = Path.Combine(_tempDir, "check-ok");
+        Directory.CreateDirectory(outputDir);
+        File.WriteAllBytes(Path.Combine(outputDir, "model.bin"), new byte[10]);
+        File.WriteAllBytes(Path.Combine(outputDir, "config.json"), new byte[5]);
+
+        var exitCode = await InvokeAsync("check", "test-repo", "model.bin", "config.json", "--output", outputDir);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task Check_MissingFiles_ReturnsOne()
+    {
+        var outputDir = Path.Combine(_tempDir, "check-missing");
+        Directory.CreateDirectory(outputDir);
+
+        var exitCode = await InvokeAsync("check", "test-repo", "nonexistent.bin", "--output", outputDir);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task Check_MixedPresentAndMissing_ReturnsOne()
+    {
+        var outputDir = Path.Combine(_tempDir, "check-mixed");
+        Directory.CreateDirectory(outputDir);
+        File.WriteAllBytes(Path.Combine(outputDir, "present.bin"), new byte[10]);
+
+        var exitCode = await InvokeAsync("check", "test-repo", "present.bin", "missing.bin", "--output", outputDir);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task Check_WithOutputOption_UsesSpecifiedDir()
+    {
+        var outputDir = Path.Combine(_tempDir, "custom-output");
+        Directory.CreateDirectory(outputDir);
+        File.WriteAllBytes(Path.Combine(outputDir, "file.txt"), new byte[1]);
+
+        var exitCode = await InvokeAsync("check", "test-repo", "file.txt", "--output", outputDir);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    // ── List command E2E ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_EmptyCacheDir_ReturnsZero()
+    {
+        var cacheDir = Path.Combine(_tempDir, "empty-cache");
+        Directory.CreateDirectory(cacheDir);
+
+        var exitCode = await InvokeAsync("list", "--cache-dir", cacheDir);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task List_PopulatedCacheDir_ReturnsZero()
+    {
+        var cacheDir = Path.Combine(_tempDir, "pop-cache");
+        TestHelpers.CreateModelDir(cacheDir, "model-a", ("weights.bin", 100));
+        TestHelpers.CreateModelDir(cacheDir, "model-b", ("config.json", 50));
+
+        var exitCode = await InvokeAsync("list", "--cache-dir", cacheDir);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task List_FormatJson_ReturnsZero()
+    {
+        var cacheDir = Path.Combine(_tempDir, "json-cache");
+        TestHelpers.CreateModelDir(cacheDir, "model-j", ("data.bin", 200));
+
+        var exitCode = await InvokeAsync("list", "--cache-dir", cacheDir, "--format", "json");
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task List_FormatTable_ReturnsZero()
+    {
+        var cacheDir = Path.Combine(_tempDir, "table-cache");
+        TestHelpers.CreateModelDir(cacheDir, "model-t", ("data.bin", 200));
+
+        var exitCode = await InvokeAsync("list", "--cache-dir", cacheDir, "--format", "table");
+
+        Assert.Equal(0, exitCode);
+    }
+
+    // ── Info command E2E ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Info_ExistingModel_ReturnsZero()
+    {
+        var cacheDir = Path.Combine(_tempDir, "info-cache");
+        TestHelpers.CreateModelDir(cacheDir, "my-model", ("weights.bin", 500));
+
+        var exitCode = await InvokeAsync("info", "my-model", "--cache-dir", cacheDir);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task Info_NonExistentModel_ReturnsOne()
+    {
+        var cacheDir = Path.Combine(_tempDir, "info-cache-empty");
+        Directory.CreateDirectory(cacheDir);
+
+        var exitCode = await InvokeAsync("info", "ghost-model", "--cache-dir", cacheDir);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task Info_FormatJson_ReturnsZero()
+    {
+        var cacheDir = Path.Combine(_tempDir, "info-json");
+        TestHelpers.CreateModelDir(cacheDir, "json-model", ("config.json", 30));
+
+        var exitCode = await InvokeAsync("info", "json-model", "--cache-dir", cacheDir, "--format", "json");
+
+        Assert.Equal(0, exitCode);
+    }
+
+    // ── Delete command E2E ───────────────────────────────────────────
+
+    [Fact]
+    public async Task Delete_ExistingModelWithForce_ReturnsZero_DirectoryRemoved()
+    {
+        var cacheDir = Path.Combine(_tempDir, "del-cache");
+        TestHelpers.CreateModelDir(cacheDir, "doomed-model", ("file.bin", 10));
+
+        var exitCode = await InvokeAsync("delete", "doomed-model", "--cache-dir", cacheDir, "--force");
+
+        Assert.Equal(0, exitCode);
+        Assert.False(Directory.Exists(Path.Combine(cacheDir, "doomed-model")));
+    }
+
+    [Fact]
+    public async Task Delete_NonExistentModel_ReturnsOne()
+    {
+        var cacheDir = Path.Combine(_tempDir, "del-cache-empty");
+        Directory.CreateDirectory(cacheDir);
+
+        var exitCode = await InvokeAsync("delete", "no-such-model", "--cache-dir", cacheDir, "--force");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    // ── DeleteFile command E2E ───────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteFile_ExistingFile_ReturnsZero_FileRemoved()
+    {
+        var cacheDir = Path.Combine(_tempDir, "delf-cache");
+        TestHelpers.CreateModelDir(cacheDir, "my-model", ("remove.txt", 20), ("keep.txt", 10));
+
+        var exitCode = await InvokeAsync("delete-file", "my-model", "remove.txt", "--cache-dir", cacheDir, "--force");
+
+        Assert.Equal(0, exitCode);
+        Assert.False(File.Exists(Path.Combine(cacheDir, "my-model", "remove.txt")));
+        Assert.True(File.Exists(Path.Combine(cacheDir, "my-model", "keep.txt")));
+    }
+
+    [Fact]
+    public async Task DeleteFile_NonExistentModel_ReturnsOne()
+    {
+        var cacheDir = Path.Combine(_tempDir, "delf-nomodel");
+        Directory.CreateDirectory(cacheDir);
+
+        var exitCode = await InvokeAsync("delete-file", "missing-model", "file.txt", "--cache-dir", cacheDir, "--force");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task DeleteFile_NonExistentFile_ReturnsOne()
+    {
+        var cacheDir = Path.Combine(_tempDir, "delf-nofile");
+        TestHelpers.CreateModelDir(cacheDir, "real-model", ("existing.txt", 10));
+
+        var exitCode = await InvokeAsync("delete-file", "real-model", "ghost.txt", "--cache-dir", cacheDir, "--force");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    // ── Purge command E2E ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Purge_PopulatedCache_ReturnsZero_AllCleared()
+    {
+        var cacheDir = Path.Combine(_tempDir, "purge-cache");
+        TestHelpers.CreateModelDir(cacheDir, "model-1", ("a.bin", 10));
+        TestHelpers.CreateModelDir(cacheDir, "model-2", ("b.bin", 20));
+
+        var exitCode = await InvokeAsync("purge", "--cache-dir", cacheDir, "--force");
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(Directory.GetDirectories(cacheDir));
+    }
+
+    [Fact]
+    public async Task Purge_EmptyCache_ReturnsZero()
+    {
+        var cacheDir = Path.Combine(_tempDir, "purge-empty");
+        Directory.CreateDirectory(cacheDir);
+
+        var exitCode = await InvokeAsync("purge", "--cache-dir", cacheDir, "--force");
+
+        Assert.Equal(0, exitCode);
+    }
+
+    // ── Download command E2E ─────────────────────────────────────────
+
+    [Fact]
+    public async Task Download_NoFilesSpecified_ReturnsOne()
+    {
+        var exitCode = await InvokeAsync("download", "test-org/test-repo");
+
+        Assert.Equal(1, exitCode);
+    }
+
+    // ── Config command E2E ───────────────────────────────────────────
+
+    [Fact]
+    public async Task Config_Show_ReturnsZero()
+    {
+        var exitCode = await InvokeAsync("config", "show");
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task Config_SetValidKey_ReturnsZero()
+    {
+        var exitCode = await InvokeAsync("config", "set", "default-revision", "test-branch");
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task Config_ResetWithForce_ReturnsZero()
+    {
+        var exitCode = await InvokeAsync("config", "reset", "--force");
+
+        Assert.Equal(0, exitCode);
+    }
+}

--- a/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/CommandParsingTests.cs
+++ b/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/CommandParsingTests.cs
@@ -1,0 +1,256 @@
+using System.CommandLine;
+using Xunit;
+using ElBruno.HuggingFace.Cli.Commands;
+
+namespace ElBruno.HuggingFace.Cli.Tests;
+
+/// <summary>
+/// Tests for command registration, argument parsing, and structural correctness.
+/// </summary>
+public sealed class CommandParsingTests
+{
+    /// <summary>
+    /// Builds the root command the same way Program.cs does.
+    /// </summary>
+    private static RootCommand BuildRootCommand()
+    {
+        var root = new RootCommand(
+            "HuggingFace Downloader CLI — download, manage, and inspect cached models from Hugging Face Hub.");
+
+        root.Add(DownloadCommand.Create());
+        root.Add(CheckCommand.Create());
+        root.Add(ListCommand.Create());
+        root.Add(InfoCommand.Create());
+        root.Add(DeleteCommand.Create());
+        root.Add(DeleteFileCommand.Create());
+        root.Add(PurgeCommand.Create());
+        root.Add(ConfigCommand.Create());
+
+        return root;
+    }
+
+    // ── Root command ────────────────────────────────────────────────
+
+    [Fact]
+    public void RootCommand_HasEightSubcommands()
+    {
+        var root = BuildRootCommand();
+
+        Assert.Equal(8, root.Subcommands.Count);
+    }
+
+    [Theory]
+    [InlineData("download")]
+    [InlineData("check")]
+    [InlineData("list")]
+    [InlineData("info")]
+    [InlineData("delete")]
+    [InlineData("delete-file")]
+    [InlineData("purge")]
+    [InlineData("config")]
+    public void RootCommand_ContainsExpectedSubcommand(string commandName)
+    {
+        var root = BuildRootCommand();
+
+        Assert.Contains(root.Subcommands, c => c.Name == commandName);
+    }
+
+    // ── Download command ────────────────────────────────────────────
+
+    [Fact]
+    public void DownloadCommand_HasExpectedArguments()
+    {
+        var cmd = DownloadCommand.Create();
+
+        Assert.Contains(cmd.Arguments, a => a.Name == "repo-id");
+        Assert.Contains(cmd.Arguments, a => a.Name == "files");
+    }
+
+    [Fact]
+    public void DownloadCommand_HasExpectedOptions()
+    {
+        var cmd = DownloadCommand.Create();
+        var optionNames = GetOptionNames(cmd);
+
+        Assert.Contains("--output", optionNames);
+        Assert.Contains("--revision", optionNames);
+        Assert.Contains("--token", optionNames);
+        Assert.Contains("--optional", optionNames);
+        Assert.Contains("--no-progress", optionNames);
+        Assert.Contains("--quiet", optionNames);
+    }
+
+    // ── Check command ───────────────────────────────────────────────
+
+    [Fact]
+    public void CheckCommand_HasExpectedArguments()
+    {
+        var cmd = CheckCommand.Create();
+
+        Assert.Contains(cmd.Arguments, a => a.Name == "repo-id");
+        Assert.Contains(cmd.Arguments, a => a.Name == "files");
+    }
+
+    [Fact]
+    public void CheckCommand_HasExpectedOptions()
+    {
+        var cmd = CheckCommand.Create();
+        var optionNames = GetOptionNames(cmd);
+
+        Assert.Contains("--output", optionNames);
+        Assert.Contains("--revision", optionNames);
+    }
+
+    // ── List command ────────────────────────────────────────────────
+
+    [Fact]
+    public void ListCommand_HasExpectedOptions()
+    {
+        var cmd = ListCommand.Create();
+        var optionNames = GetOptionNames(cmd);
+
+        Assert.Contains("--cache-dir", optionNames);
+        Assert.Contains("--format", optionNames);
+    }
+
+    // ── Info command ────────────────────────────────────────────────
+
+    [Fact]
+    public void InfoCommand_HasExpectedArgument()
+    {
+        var cmd = InfoCommand.Create();
+
+        Assert.Contains(cmd.Arguments, a => a.Name == "repo-id");
+    }
+
+    [Fact]
+    public void InfoCommand_HasExpectedOptions()
+    {
+        var cmd = InfoCommand.Create();
+        var optionNames = GetOptionNames(cmd);
+
+        Assert.Contains("--cache-dir", optionNames);
+        Assert.Contains("--format", optionNames);
+    }
+
+    // ── Delete command ──────────────────────────────────────────────
+
+    [Fact]
+    public void DeleteCommand_HasExpectedArgument()
+    {
+        var cmd = DeleteCommand.Create();
+
+        Assert.Contains(cmd.Arguments, a => a.Name == "repo-id");
+    }
+
+    [Fact]
+    public void DeleteCommand_HasExpectedOptions()
+    {
+        var cmd = DeleteCommand.Create();
+        var optionNames = GetOptionNames(cmd);
+
+        Assert.Contains("--cache-dir", optionNames);
+        Assert.Contains("--force", optionNames);
+    }
+
+    // ── DeleteFile command ──────────────────────────────────────────
+
+    [Fact]
+    public void DeleteFileCommand_HasExpectedArguments()
+    {
+        var cmd = DeleteFileCommand.Create();
+
+        Assert.Contains(cmd.Arguments, a => a.Name == "repo-id");
+        Assert.Contains(cmd.Arguments, a => a.Name == "file");
+    }
+
+    [Fact]
+    public void DeleteFileCommand_HasExpectedOptions()
+    {
+        var cmd = DeleteFileCommand.Create();
+        var optionNames = GetOptionNames(cmd);
+
+        Assert.Contains("--cache-dir", optionNames);
+        Assert.Contains("--force", optionNames);
+    }
+
+    // ── Purge command ───────────────────────────────────────────────
+
+    [Fact]
+    public void PurgeCommand_HasExpectedOptions()
+    {
+        var cmd = PurgeCommand.Create();
+        var optionNames = GetOptionNames(cmd);
+
+        Assert.Contains("--cache-dir", optionNames);
+        Assert.Contains("--force", optionNames);
+    }
+
+    // ── Config command ──────────────────────────────────────────────
+
+    [Fact]
+    public void ConfigCommand_HasShowSetResetSubcommands()
+    {
+        var cmd = ConfigCommand.Create();
+
+        Assert.Contains(cmd.Subcommands, c => c.Name == "show");
+        Assert.Contains(cmd.Subcommands, c => c.Name == "set");
+        Assert.Contains(cmd.Subcommands, c => c.Name == "reset");
+    }
+
+    [Fact]
+    public void ConfigCommand_HasExactlyThreeSubcommands()
+    {
+        var cmd = ConfigCommand.Create();
+
+        Assert.Equal(3, cmd.Subcommands.Count);
+    }
+
+    // ── Help text generation ────────────────────────────────────────
+
+    [Fact]
+    public void AllCommands_CreateWithoutThrowing()
+    {
+        // Ensures static Create() methods execute without errors
+        var commands = new Command[]
+        {
+            DownloadCommand.Create(),
+            CheckCommand.Create(),
+            ListCommand.Create(),
+            InfoCommand.Create(),
+            DeleteCommand.Create(),
+            DeleteFileCommand.Create(),
+            PurgeCommand.Create(),
+            ConfigCommand.Create(),
+        };
+
+        Assert.All(commands, cmd =>
+        {
+            Assert.NotNull(cmd);
+            Assert.False(string.IsNullOrEmpty(cmd.Name));
+            Assert.False(string.IsNullOrEmpty(cmd.Description));
+        });
+    }
+
+    [Fact]
+    public void RootCommand_HelpTextGeneration_DoesNotThrow()
+    {
+        var root = BuildRootCommand();
+        var config = new CommandLineConfiguration(root);
+
+        // Invoking --help shouldn't throw — the return code is informational
+        var exception = Record.Exception(() =>
+        {
+            config.InvokeAsync(["--help"]).GetAwaiter().GetResult();
+        });
+
+        Assert.Null(exception);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private static List<string> GetOptionNames(Command cmd)
+    {
+        return cmd.Options.Select(o => o.Name).ToList();
+    }
+}

--- a/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/ConfigManagerEdgeCaseTests.cs
+++ b/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/ConfigManagerEdgeCaseTests.cs
@@ -1,0 +1,193 @@
+using Xunit;
+using ElBruno.HuggingFace.Cli.Models;
+using ElBruno.HuggingFace.Cli.Services;
+
+namespace ElBruno.HuggingFace.Cli.Tests;
+
+/// <summary>
+/// Edge case tests for <see cref="ConfigManager"/> — corruption, case-insensitivity, rapid cycles.
+/// </summary>
+[Collection("ConfigFile")]
+public sealed class ConfigManagerEdgeCaseTests : IDisposable
+{
+    private readonly string _configPath;
+    private readonly string? _originalContent;
+    private readonly bool _originalExisted;
+
+    public ConfigManagerEdgeCaseTests()
+    {
+        _configPath = ConfigManager.GetConfigPath();
+        _originalExisted = File.Exists(_configPath);
+        _originalContent = _originalExisted ? File.ReadAllText(_configPath) : null;
+
+        if (_originalExisted)
+            File.Delete(_configPath);
+    }
+
+    public void Dispose()
+    {
+        if (_originalExisted && _originalContent is not null)
+        {
+            var dir = Path.GetDirectoryName(_configPath)!;
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(_configPath, _originalContent);
+        }
+        else if (File.Exists(_configPath))
+        {
+            File.Delete(_configPath);
+        }
+    }
+
+    // ── Corrupted config file ───────────────────────────────────────
+
+    [Fact]
+    public void Load_CorruptedJsonConfig_ReturnsDefaults()
+    {
+        var dir = Path.GetDirectoryName(_configPath)!;
+        if (!Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        File.WriteAllText(_configPath, "NOT VALID JSON {{{");
+
+        var manager = new ConfigManager();
+        var config = manager.Load();
+
+        Assert.Null(config.CacheDirectory);
+        Assert.Null(config.DefaultToken);
+        Assert.Equal("main", config.DefaultRevision);
+        Assert.False(config.NoProgress);
+    }
+
+    // ── SetValue case insensitivity ─────────────────────────────────
+
+    [Theory]
+    [InlineData("Cache-Dir")]
+    [InlineData("CACHE-DIR")]
+    [InlineData("cache-dir")]
+    [InlineData("Cache-dir")]
+    public void SetValue_CaseInsensitiveKey_Works(string key)
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig();
+
+        var result = manager.SetValue(config, key, @"C:\test");
+
+        Assert.True(result);
+        Assert.Equal(@"C:\test", config.CacheDirectory);
+    }
+
+    [Theory]
+    [InlineData("Default-Token")]
+    [InlineData("DEFAULT-TOKEN")]
+    public void SetValue_DefaultToken_CaseInsensitive_Works(string key)
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig();
+
+        var result = manager.SetValue(config, key, "my-token");
+
+        Assert.True(result);
+        Assert.Equal("my-token", config.DefaultToken);
+    }
+
+    // ── GetConfigDirectory returns platform-appropriate path ────────
+
+    [Fact]
+    public void GetConfigDirectory_ReturnsNonEmptyPath()
+    {
+        var dir = ConfigManager.GetConfigDirectory();
+
+        Assert.False(string.IsNullOrWhiteSpace(dir));
+        Assert.Contains("hfdownload", dir);
+    }
+
+    // ── Save overwrites existing config file ────────────────────────
+
+    [Fact]
+    public void Save_Overwrites_ExistingConfigFile()
+    {
+        var manager = new ConfigManager();
+        var first = new CliConfig { DefaultRevision = "first" };
+        manager.Save(first);
+
+        var second = new CliConfig { DefaultRevision = "second" };
+        manager.Save(second);
+
+        var loaded = manager.Load();
+        Assert.Equal("second", loaded.DefaultRevision);
+    }
+
+    // ── Rapid save/load cycles ──────────────────────────────────────
+
+    [Fact]
+    public void RapidSaveLoadCycles_DoNotCorruptData()
+    {
+        var manager = new ConfigManager();
+
+        for (int i = 0; i < 20; i++)
+        {
+            var config = new CliConfig
+            {
+                DefaultRevision = $"rev-{i}",
+                CacheDirectory = $@"C:\cache-{i}",
+                NoProgress = i % 2 == 0,
+            };
+            manager.Save(config);
+
+            var loaded = manager.Load();
+            Assert.Equal($"rev-{i}", loaded.DefaultRevision);
+            Assert.Equal($@"C:\cache-{i}", loaded.CacheDirectory);
+            Assert.Equal(i % 2 == 0, loaded.NoProgress);
+        }
+    }
+
+    // ── Config with all null/empty optional values roundtrips ───────
+
+    [Fact]
+    public void Config_AllNullOptionalValues_RoundtripsCorrectly()
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig
+        {
+            CacheDirectory = null,
+            DefaultToken = null,
+            DefaultRevision = "main",
+            NoProgress = false,
+        };
+
+        manager.Save(config);
+        var loaded = manager.Load();
+
+        Assert.Null(loaded.CacheDirectory);
+        Assert.Null(loaded.DefaultToken);
+        Assert.Equal("main", loaded.DefaultRevision);
+        Assert.False(loaded.NoProgress);
+    }
+
+    // ── SetValue with whitespace-only strings ───────────────────────
+
+    [Fact]
+    public void SetValue_CacheDir_WhitespaceOnly_SetsNull()
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig { CacheDirectory = @"C:\old" };
+
+        var result = manager.SetValue(config, "cache-dir", "   ");
+
+        Assert.True(result);
+        Assert.Null(config.CacheDirectory);
+    }
+
+    [Fact]
+    public void SetValue_DefaultToken_WhitespaceOnly_SetsNull()
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig { DefaultToken = "old-token" };
+
+        var result = manager.SetValue(config, "default-token", "  \t  ");
+
+        Assert.True(result);
+        Assert.Null(config.DefaultToken);
+    }
+}

--- a/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/ConfigManagerTests.cs
+++ b/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/ConfigManagerTests.cs
@@ -1,0 +1,315 @@
+using Xunit;
+using ElBruno.HuggingFace.Cli.Models;
+using ElBruno.HuggingFace.Cli.Services;
+
+namespace ElBruno.HuggingFace.Cli.Tests;
+
+/// <summary>
+/// Tests for <see cref="ConfigManager"/> — persistent config load/save/reset and value logic.
+/// Disk-touching tests back up and restore the real config file via IDisposable.
+/// </summary>
+public sealed class ConfigManagerTests : IDisposable
+{
+    private readonly string _configPath;
+    private readonly string? _originalContent;
+    private readonly bool _originalExisted;
+
+    public ConfigManagerTests()
+    {
+        _configPath = ConfigManager.GetConfigPath();
+        _originalExisted = File.Exists(_configPath);
+        _originalContent = _originalExisted ? File.ReadAllText(_configPath) : null;
+
+        // Start each test with a clean slate
+        if (_originalExisted)
+            File.Delete(_configPath);
+    }
+
+    public void Dispose()
+    {
+        // Restore original config state
+        if (_originalExisted && _originalContent is not null)
+        {
+            var dir = Path.GetDirectoryName(_configPath)!;
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(_configPath, _originalContent);
+        }
+        else if (File.Exists(_configPath))
+        {
+            File.Delete(_configPath);
+        }
+    }
+
+    // ── Load ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Load_NoConfigFile_ReturnsDefaults()
+    {
+        var manager = new ConfigManager();
+
+        var config = manager.Load();
+
+        Assert.Null(config.CacheDirectory);
+        Assert.Null(config.DefaultToken);
+        Assert.Equal("main", config.DefaultRevision);
+        Assert.False(config.NoProgress);
+    }
+
+    // ── Save ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Save_CreatesConfigFileAndDirectory()
+    {
+        var dir = Path.GetDirectoryName(_configPath)!;
+        if (Directory.Exists(dir))
+            Directory.Delete(dir, recursive: true);
+
+        var manager = new ConfigManager();
+        var config = new CliConfig { DefaultRevision = "test-branch" };
+
+        manager.Save(config);
+
+        Assert.True(File.Exists(_configPath));
+    }
+
+    // ── Load roundtrip ──────────────────────────────────────────────
+
+    [Fact]
+    public void Load_RoundtripsSavedValues()
+    {
+        var manager = new ConfigManager();
+        var original = new CliConfig
+        {
+            CacheDirectory = @"C:\my\cache",
+            DefaultToken = "hf_test_token_123",
+            DefaultRevision = "dev",
+            NoProgress = true,
+        };
+
+        manager.Save(original);
+        var loaded = manager.Load();
+
+        Assert.Equal(original.CacheDirectory, loaded.CacheDirectory);
+        Assert.Equal(original.DefaultToken, loaded.DefaultToken);
+        Assert.Equal(original.DefaultRevision, loaded.DefaultRevision);
+        Assert.Equal(original.NoProgress, loaded.NoProgress);
+    }
+
+    // ── SetValue ────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetValue_CacheDir_SetsValue()
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig();
+
+        var result = manager.SetValue(config, "cache-dir", @"D:\models");
+
+        Assert.True(result);
+        Assert.Equal(@"D:\models", config.CacheDirectory);
+    }
+
+    [Fact]
+    public void SetValue_DefaultToken_SetsValue()
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig();
+
+        var result = manager.SetValue(config, "default-token", "hf_abc123");
+
+        Assert.True(result);
+        Assert.Equal("hf_abc123", config.DefaultToken);
+    }
+
+    [Fact]
+    public void SetValue_DefaultRevision_SetsValue()
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig();
+
+        var result = manager.SetValue(config, "default-revision", "v2.0");
+
+        Assert.True(result);
+        Assert.Equal("v2.0", config.DefaultRevision);
+    }
+
+    [Fact]
+    public void SetValue_NoProgress_SetsTrue()
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig();
+
+        var result = manager.SetValue(config, "no-progress", "true");
+
+        Assert.True(result);
+        Assert.True(config.NoProgress);
+    }
+
+    [Fact]
+    public void SetValue_NoProgress_SetsFalse()
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig { NoProgress = true };
+
+        var result = manager.SetValue(config, "no-progress", "false");
+
+        Assert.True(result);
+        Assert.False(config.NoProgress);
+    }
+
+    [Fact]
+    public void SetValue_UnknownKey_ReturnsFalse()
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig();
+
+        var result = manager.SetValue(config, "nonexistent-key", "value");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void SetValue_NoProgress_InvalidBoolean_ReturnsFalse()
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig();
+
+        var result = manager.SetValue(config, "no-progress", "not-a-bool");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void SetValue_CacheDir_EmptyString_SetsNull()
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig { CacheDirectory = @"C:\old" };
+
+        var result = manager.SetValue(config, "cache-dir", "");
+
+        Assert.True(result);
+        Assert.Null(config.CacheDirectory);
+    }
+
+    [Fact]
+    public void SetValue_DefaultToken_EmptyString_SetsNull()
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig { DefaultToken = "old-token" };
+
+        var result = manager.SetValue(config, "default-token", "");
+
+        Assert.True(result);
+        Assert.Null(config.DefaultToken);
+    }
+
+    [Fact]
+    public void SetValue_DefaultRevision_EmptyString_SetsMain()
+    {
+        var manager = new ConfigManager();
+        var config = new CliConfig { DefaultRevision = "dev" };
+
+        var result = manager.SetValue(config, "default-revision", "");
+
+        Assert.True(result);
+        Assert.Equal("main", config.DefaultRevision);
+    }
+
+    // ── GetValue ────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetValue_TokenSet_MasksValue()
+    {
+        var config = new CliConfig { DefaultToken = "hf_secret_token" };
+
+        var result = ConfigManager.GetValue(config, "default-token");
+
+        Assert.Equal("****", result);
+    }
+
+    [Fact]
+    public void GetValue_TokenNull_ReturnsNotSet()
+    {
+        var config = new CliConfig { DefaultToken = null };
+
+        var result = ConfigManager.GetValue(config, "default-token");
+
+        Assert.Equal("(not set)", result);
+    }
+
+    [Fact]
+    public void GetValue_CacheDirNull_ReturnsPlatformDefault()
+    {
+        var config = new CliConfig { CacheDirectory = null };
+
+        var result = ConfigManager.GetValue(config, "cache-dir");
+
+        Assert.Equal("(platform default)", result);
+    }
+
+    [Fact]
+    public void GetValue_CacheDirSet_ReturnsActualPath()
+    {
+        var config = new CliConfig { CacheDirectory = @"C:\custom\cache" };
+
+        var result = ConfigManager.GetValue(config, "cache-dir");
+
+        Assert.Equal(@"C:\custom\cache", result);
+    }
+
+    [Fact]
+    public void GetValue_DefaultRevision_ReturnsValue()
+    {
+        var config = new CliConfig { DefaultRevision = "v3" };
+
+        var result = ConfigManager.GetValue(config, "default-revision");
+
+        Assert.Equal("v3", result);
+    }
+
+    [Fact]
+    public void GetValue_NoProgress_ReturnsBoolString()
+    {
+        var config = new CliConfig { NoProgress = true };
+
+        var result = ConfigManager.GetValue(config, "no-progress");
+
+        Assert.Equal("true", result);
+    }
+
+    [Fact]
+    public void GetValue_UnknownKey_ReturnsNull()
+    {
+        var config = new CliConfig();
+
+        var result = ConfigManager.GetValue(config, "totally-fake-key");
+
+        Assert.Null(result);
+    }
+
+    // ── Reset ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Reset_ConfigFileExists_DeletesAndReturnsTrue()
+    {
+        var manager = new ConfigManager();
+        manager.Save(new CliConfig { DefaultRevision = "disposable" });
+        Assert.True(File.Exists(_configPath));
+
+        var result = manager.Reset();
+
+        Assert.True(result);
+        Assert.False(File.Exists(_configPath));
+    }
+
+    [Fact]
+    public void Reset_NoConfigFile_ReturnsFalse()
+    {
+        var manager = new ConfigManager();
+
+        var result = manager.Reset();
+
+        Assert.False(result);
+    }
+}

--- a/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/ConfigManagerTests.cs
+++ b/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/ConfigManagerTests.cs
@@ -8,6 +8,7 @@ namespace ElBruno.HuggingFace.Cli.Tests;
 /// Tests for <see cref="ConfigManager"/> — persistent config load/save/reset and value logic.
 /// Disk-touching tests back up and restore the real config file via IDisposable.
 /// </summary>
+[Collection("ConfigFile")]
 public sealed class ConfigManagerTests : IDisposable
 {
     private readonly string _configPath;

--- a/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/ElBruno.HuggingFace.Downloader.Cli.Tests.csproj
+++ b/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/ElBruno.HuggingFace.Downloader.Cli.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ElBruno.HuggingFace.Downloader.Cli\ElBruno.HuggingFace.Downloader.Cli.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/RegressionTests.cs
+++ b/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/RegressionTests.cs
@@ -1,0 +1,183 @@
+using Xunit;
+using ElBruno.HuggingFace.Cli.Models;
+using ElBruno.HuggingFace.Cli.Services;
+
+namespace ElBruno.HuggingFace.Cli.Tests;
+
+/// <summary>
+/// Multi-step workflow regression tests for CacheManager and ConfigManager interactions.
+/// </summary>
+[Collection("ConfigFile")]
+public sealed class RegressionTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly CacheManager _cacheManager;
+    private readonly string _configPath;
+    private readonly string? _originalConfigContent;
+    private readonly bool _originalConfigExisted;
+
+    public RegressionTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(_tempDir);
+        _cacheManager = new CacheManager();
+
+        _configPath = ConfigManager.GetConfigPath();
+        _originalConfigExisted = File.Exists(_configPath);
+        _originalConfigContent = _originalConfigExisted ? File.ReadAllText(_configPath) : null;
+
+        if (_originalConfigExisted)
+            File.Delete(_configPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+
+        // Restore config
+        if (_originalConfigExisted && _originalConfigContent is not null)
+        {
+            var dir = Path.GetDirectoryName(_configPath)!;
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(_configPath, _originalConfigContent);
+        }
+        else if (File.Exists(_configPath))
+        {
+            File.Delete(_configPath);
+        }
+    }
+
+    // ── Delete model → list no longer includes it ───────────────────
+
+    [Fact]
+    public void DeleteModel_ThenList_NoLongerIncludesIt()
+    {
+        TestHelpers.CreateModelDir(_tempDir, "model-a", ("a.bin", 10));
+        TestHelpers.CreateModelDir(_tempDir, "model-b", ("b.bin", 20));
+
+        _cacheManager.DeleteModel(_tempDir, "model-a");
+        var models = _cacheManager.GetCachedModels(_tempDir);
+
+        Assert.Single(models);
+        Assert.Equal("model-b", models[0].Name);
+    }
+
+    // ── Purge → list returns empty → info returns null ──────────────
+
+    [Fact]
+    public void Purge_ThenList_Empty_ThenInfo_ReturnsNull()
+    {
+        TestHelpers.CreateModelDir(_tempDir, "model-x", ("x.bin", 100));
+        TestHelpers.CreateModelDir(_tempDir, "model-y", ("y.bin", 200));
+
+        _cacheManager.PurgeAll(_tempDir);
+
+        var models = _cacheManager.GetCachedModels(_tempDir);
+        Assert.Empty(models);
+
+        var info = _cacheManager.GetModelDetails(_tempDir, "model-x");
+        Assert.Null(info);
+    }
+
+    // ── Config set → show reflects → reset → back to defaults ──────
+
+    [Fact]
+    public void ConfigSet_ThenShow_ThenReset_ReturnsDefaults()
+    {
+        var manager = new ConfigManager();
+        var config = manager.Load();
+
+        manager.SetValue(config, "default-revision", "custom-branch");
+        manager.SetValue(config, "no-progress", "true");
+        manager.Save(config);
+
+        var reloaded = manager.Load();
+        Assert.Equal("custom-branch", reloaded.DefaultRevision);
+        Assert.True(reloaded.NoProgress);
+
+        manager.Reset();
+
+        var afterReset = manager.Load();
+        Assert.Equal("main", afterReset.DefaultRevision);
+        Assert.False(afterReset.NoProgress);
+    }
+
+    // ── Create models → list → delete one → list → correct count ───
+
+    [Fact]
+    public void CreateModels_List_DeleteOne_List_CorrectCount()
+    {
+        TestHelpers.CreateModelDir(_tempDir, "alpha", ("a.bin", 10));
+        TestHelpers.CreateModelDir(_tempDir, "beta", ("b.bin", 20));
+        TestHelpers.CreateModelDir(_tempDir, "gamma", ("c.bin", 30));
+
+        var beforeDelete = _cacheManager.GetCachedModels(_tempDir);
+        Assert.Equal(3, beforeDelete.Count);
+
+        _cacheManager.DeleteModel(_tempDir, "beta");
+
+        var afterDelete = _cacheManager.GetCachedModels(_tempDir);
+        Assert.Equal(2, afterDelete.Count);
+        Assert.DoesNotContain(afterDelete, m => m.Name == "beta");
+    }
+
+    // ── DeleteFile → GetModelDetails shows reduced count/size ───────
+
+    [Fact]
+    public void DeleteFile_ThenModelDetails_ShowsReducedFileCountAndSize()
+    {
+        TestHelpers.CreateModelDir(_tempDir, "file-model",
+            ("big.bin", 1000), ("small.txt", 100), ("config.json", 50));
+
+        var before = _cacheManager.GetModelDetails(_tempDir, "file-model");
+        Assert.NotNull(before);
+        Assert.Equal(3, before.FileCount);
+        Assert.Equal(1150, before.TotalSize);
+
+        _cacheManager.DeleteFile(_tempDir, "file-model", "big.bin");
+
+        var after = _cacheManager.GetModelDetails(_tempDir, "file-model");
+        Assert.NotNull(after);
+        Assert.Equal(2, after.FileCount);
+        Assert.Equal(150, after.TotalSize);
+    }
+
+    // ── PurgeAll → empty → repopulate → works again ─────────────────
+
+    [Fact]
+    public void PurgeAll_ThenRepopulate_GetCachedModelsWorksAgain()
+    {
+        TestHelpers.CreateModelDir(_tempDir, "model-1", ("f.bin", 10));
+        _cacheManager.PurgeAll(_tempDir);
+
+        Assert.Empty(_cacheManager.GetCachedModels(_tempDir));
+
+        TestHelpers.CreateModelDir(_tempDir, "model-2", ("g.bin", 20));
+
+        var result = _cacheManager.GetCachedModels(_tempDir);
+        Assert.Single(result);
+        Assert.Equal("model-2", result[0].Name);
+    }
+
+    // ── Save config → modify → save again → load shows latest ──────
+
+    [Fact]
+    public void SaveConfig_Modify_SaveAgain_LoadShowsLatest()
+    {
+        var manager = new ConfigManager();
+
+        var config1 = new CliConfig { DefaultRevision = "v1", CacheDirectory = @"C:\first" };
+        manager.Save(config1);
+
+        var config2 = manager.Load();
+        config2.DefaultRevision = "v2";
+        config2.CacheDirectory = @"C:\second";
+        manager.Save(config2);
+
+        var final = manager.Load();
+        Assert.Equal("v2", final.DefaultRevision);
+        Assert.Equal(@"C:\second", final.CacheDirectory);
+    }
+}

--- a/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/TestHelpers.cs
+++ b/tests/ElBruno.HuggingFace.Downloader.Cli.Tests/TestHelpers.cs
@@ -1,0 +1,48 @@
+using System.CommandLine;
+using ElBruno.HuggingFace.Cli.Commands;
+
+namespace ElBruno.HuggingFace.Cli.Tests;
+
+/// <summary>
+/// Shared helpers for CLI test classes.
+/// </summary>
+internal static class TestHelpers
+{
+    /// <summary>
+    /// Builds the root command the same way Program.cs does.
+    /// </summary>
+    public static RootCommand BuildRootCommand()
+    {
+        var root = new RootCommand(
+            "HuggingFace Downloader CLI — download, manage, and inspect cached models from Hugging Face Hub.");
+
+        root.Add(DownloadCommand.Create());
+        root.Add(CheckCommand.Create());
+        root.Add(ListCommand.Create());
+        root.Add(InfoCommand.Create());
+        root.Add(DeleteCommand.Create());
+        root.Add(DeleteFileCommand.Create());
+        root.Add(PurgeCommand.Create());
+        root.Add(ConfigCommand.Create());
+
+        return root;
+    }
+
+    /// <summary>
+    /// Creates a model directory with the given files inside a cache root.
+    /// </summary>
+    public static void CreateModelDir(string cacheDir, string modelName, params (string fileName, int size)[] files)
+    {
+        var modelDir = Path.Combine(cacheDir, modelName);
+        Directory.CreateDirectory(modelDir);
+
+        foreach (var (fileName, size) in files)
+        {
+            var filePath = Path.Combine(modelDir, fileName);
+            var dir = Path.GetDirectoryName(filePath)!;
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllBytes(filePath, new byte[size]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add `hfdownload` CLI tool as a .NET global tool published to NuGet.

### New Package: `ElBruno.HuggingFace.Downloader.Cli`

Install: `dotnet tool install -g ElBruno.HuggingFace.Downloader.Cli`

### 8 Commands

| Command | Description |
|---------|-------------|
| `download` | Download files from HF repos with Spectre.Console progress bars |
| `check` | Verify files exist locally (exit code 0/1) |
| `list` | List cached models (table or JSON) |
| `info` | Show model details and file listing |
| `delete` | Delete a cached model (with confirmation) |
| `delete-file` | Delete a single file from a model |
| `purge` | Delete all cached models |
| `config` | Show/set/reset persistent configuration |

### Test Coverage

- **129 CLI tests** (unit, E2E, edge-case, regression)
- **147 library tests** unchanged
- **276 total**, all passing

### Changes

- `src/ElBruno.HuggingFace.Downloader.Cli/` — CLI project (Commands, Services, Models)
- `tests/ElBruno.HuggingFace.Downloader.Cli.Tests/` — comprehensive test project
- `docs/CLI_REFERENCE.md` — full command reference
- `README.md` — updated with CLI installation and usage
- `.github/workflows/publish.yml` — packs both library and CLI tool